### PR TITLE
replaces agent err field of type error, with type string

### DIFF
--- a/agent/types/types.go
+++ b/agent/types/types.go
@@ -20,7 +20,7 @@ type AgentErrMessage struct {
 	AccountName string `json:"accountName"`
 	ClusterName string `json:"clusterName"`
 
-	Error  error          `json:"error"`
+	Error  string         `json:"error"`
 	Action Action         `json:"action"`
 	Object map[string]any `json:"object"`
 	// Yamls  []byte        `json:"yamls"`


### PR DESCRIPTION
agent err message, had field `err` of type `error`, which made it impossible to unmarshal into. Now replaced it with string type.

Also, error-on-apply handler, was setting up wrong account name, and cluster name, fixed it.
 