### PR TITLE
fix(agent): fixes infinite token regeneration

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,8 @@ vars:
   ImagePrefix: "ghcr.io/kloudlite/operators"
   dockerRegistry: registry.kloudlite.io
   KlControllerGen: "./bin/kl-controller-gen"
-  KlTemplatizer: "./bin/kl-templatizer"
+  # KlTemplatizer: "./bin/kl-templatizer"
+  KlTemplatizer: "go run cmd/template/main.go"
 
 tasks:
   new-kind:
@@ -50,7 +51,8 @@ tasks:
         for file in $(ls config/crd/bases/*.yaml)
         do
           cat $file
-          echo "---"
+          # actually, don't need it as all crds have --- at the start
+          # echo "---"
         done
 
   # helm-pull:
@@ -93,6 +95,8 @@ tasks:
     vars:
 #      Image: "{{.dockerRegistry}}/kloudlite/operators/${ENV_NAME}/{{.Name}}:${IMAGE_TAG}"
 #      Image: '{{ printf "%s/kloudlite/operators/{{.ENV_NAME}}/%s:{{.IMAGE_TAG}}" .dockerRegistry .Name }}'
+      Name:
+        sh: ls ./operators | fzf --prompt "generate yaml for operator> "
       Image: '{{ printf "%s/kloudlite/operators/{{.EnvName}}/%s:{{.ImageTag}}" .dockerRegistry .Name }}'
       Namespace: '{{ printf "{{.Namespace}}" }}'
       SvcAccountName: '{{ printf "{{.SvcAccountName}}" }}'

--- a/agent/main.go
+++ b/agent/main.go
@@ -129,8 +129,8 @@ func (g *grpcHandler) ensureAccessToken() error {
 		g.logger.Infof("accessToken is invalid, requesting new accessToken ...")
 	}
 
-	if validationOut.Valid {
-	  g.logger.Infof("accessToken is valid, proceeding with it ...")
+	if validationOut != nil && validationOut.Valid {
+		g.logger.Infof("accessToken is valid, proceeding with it ...")
 		return nil
 	}
 
@@ -182,9 +182,7 @@ func (g *grpcHandler) run() error {
 	ctx, cf := context.WithCancel(context.TODO())
 	defer cf()
 
-	md := metadata.MD{}
-	md.Set("authorization", g.ev.AccessToken)
-	outgoingCtx := metadata.NewOutgoingContext(ctx, md)
+	outgoingCtx := metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", g.ev.AccessToken))
 
 	errorsCli, err := g.msgDispatchCli.ReceiveErrors(outgoingCtx)
 	if err != nil {


### PR DESCRIPTION
once token's validity is confirmed, agent should have proceeded with the same token, instead of querying message-office for a new one, which is happening, prior to this commit