### PR TITLE
fix(operators/resource-watcher): implements new message-office auth s…

### DIFF
--- a/operators/resource-watcher/internal/env/env.go
+++ b/operators/resource-watcher/internal/env/env.go
@@ -14,7 +14,7 @@ type Env struct {
 
 	AccountName string `env:"ACCOUNT_NAME" required:"true"`
 	ClusterName string `env:"CLUSTER_NAME" required:"true"`
-	//AccessToken string `env:"ACCESS_TOKEN" required:"true"`
+	AccessToken string `env:"ACCESS_TOKEN" required:"true"`
 
 	ClusterIdentitySecretName      string `env:"CLUSTER_IDENTITY_SECRET_NAME" required:"true"`
 	ClusterIdentitySecretNamespace string `env:"CLUSTER_IDENTITY_SECRET_NAMESPACE" required:"true"`

--- a/operators/resource-watcher/main.go
+++ b/operators/resource-watcher/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"google.golang.org/grpc"
 
-	// clustersv1 "github.com/kloudlite/operator/apis/clusters/v1"
+	clustersv1 "github.com/kloudlite/operator/apis/clusters/v1"
 	// byocClientWatcher "github.com/kloudlite/operator/operators/resource-watcher/internal/controllers/byoc-client"
 
 	crdsv1 "github.com/kloudlite/operator/apis/crds/v1"
@@ -23,9 +23,9 @@ func main() {
 	mgr := operator.New("resource-watcher")
 
 	getGrpcConnection := func() (*grpc.ClientConn, error) {
-		if mgr.Operator().IsDev {
-			return libGrpc.Connect(ev.GrpcAddr)
-		}
+		// if mgr.Operator().IsDev {
+		// 	return libGrpc.Connect(ev.GrpcAddr)
+		// }
 		return libGrpc.ConnectSecure(ev.GrpcAddr)
 	}
 
@@ -33,7 +33,7 @@ func main() {
 		crdsv1.AddToScheme,
 		mongodbMsvcv1.AddToScheme, mysqlMsvcv1.AddToScheme, redisMsvcv1.AddToScheme,
 		serverlessv1.AddToScheme,
-		// clustersv1.AddToScheme,
+		clustersv1.AddToScheme,
 	)
 
 	mgr.RegisterControllers(


### PR DESCRIPTION
we had to implement new access token authentitcation strategy in resource watcher, without it none of the status updates were goingt through message office, as all of them were getting rejected with invalid auth

We already had implemented these things in [`kloudlite-agent`](./agent).

Now, both the components that communicate to message office, have the new authentication strategy implemented.
