### PR TITLE
fix(operators/nodepool): controlled deletion of nodes

### DIFF
--- a/operators/nodepool/internal/templates/nodepool-job.yml.tpl
+++ b/operators/nodepool/internal/templates/nodepool-job.yml.tpl
@@ -2,6 +2,7 @@
 {{- $jobNamespace := get . "job-namespace" }} 
 
 {{- $labels := get . "labels" | default dict }} 
+{{- $annotations := get . "annotations" | default dict }} 
 {{- $ownerRefs := get . "owner-refs" | default list }}
 
 {{- $jobNodeSelector := get . "job-node-selector" }} 
@@ -28,6 +29,7 @@ metadata:
   name: {{$jobName}}
   namespace: {{$jobNamespace}}
   labels: {{$labels | toYAML | nindent 4}}
+  annotations: {{$annotations | toYAML | nindent 4}}
   ownerReferences: {{$ownerRefs | toYAML| nindent 4}}
 spec:
   template:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -113,8 +113,8 @@ const (
 
 	RegionKey string = "kloudlite.io/region"
 
-	NodePoolNameKey string = "kloudlite.io/nodepool.name"
-	NodeNameKey     string = "kloudlite.io/node.name"
+	NodePoolNameKey   string = "kloudlite.io/nodepool.name"
+	NodeNameKey       string = "kloudlite.io/node.name"
 
 	IsNodeControllerJob string = "kloudlite.io/is-nodectrl-job"
 	ForceDeleteKey      string = "kloudlite.io/force-delete"


### PR DESCRIPTION
- nodepool controller now allows for controlled deletion of nodes, either by cluster autoscaler, or by manually scaling down the nodepool
- also, removed generating node names by numbers, as it allows for deferred deletion of nodes, like after a future point in time
- loads of refactorings in nodepool controller