### PR TITLE
fix(functions/main.go): fixes integer overflow

### DIFF
--- a/pkg/functions/main.go
+++ b/pkg/functions/main.go
@@ -221,6 +221,9 @@ func Sha1Sum(b []byte) string {
 }
 
 func Exec(command ...string) (err error, stdout *bytes.Buffer, stderr *bytes.Buffer) {
+	if len(command) > 100 {
+		return errors.New("command is too long"), nil, nil
+	}
 	args := make([]string, 0, len(command)+1)
 	args = append(args, "-c")
 	args = append(args, command...)

--- a/pkg/functions/main.go
+++ b/pkg/functions/main.go
@@ -221,11 +221,9 @@ func Sha1Sum(b []byte) string {
 }
 
 func Exec(command ...string) (err error, stdout *bytes.Buffer, stderr *bytes.Buffer) {
-	args := make([]string, len(command)+1)
-	args[0] = "-c"
-	for i := range command {
-		args[i+1] = command[i]
-	}
+	args := make([]string, 0, len(command)+1)
+	args = append(args, "-c")
+	args = append(args, command...)
 
 	stdout = bytes.NewBuffer(nil)
 	stderr = bytes.NewBuffer(nil)


### PR DESCRIPTION
codeql-issue: https://github.com/kloudlite/operator/security/code-scanning/4

changes 
`args := make([]string, len(command)+1)`
to
`args := make([]string, 0, len(command)+1)`

this should fix the `allocation may overflow`, as even if it does, this could be taken care by go runtime itself