### PR TITLE
CI: removed fixed value "wg-" and made changes according to latest wg

### DIFF
--- a/pkg/templates/templates/app.yml.tpl
+++ b/pkg/templates/templates/app.yml.tpl
@@ -99,7 +99,7 @@ metadata:
 spec:
   type: ExternalName
   {{- if $isIntercepted }}
-  externalName: {{.Spec.Intercept.ToDevice}}.wg-{{$accountName}}.svc.{{$clusterDnsSuffix}}
+  externalName: {{.Spec.Intercept.ToDevice}}.{{.Namespace}}.svc.{{$clusterDnsSuffix}}
   {{- else}}
   externalName: {{.Name}}-internal.{{.Namespace}}.svc.{{$clusterDnsSuffix}}
   {{- end }}


### PR DESCRIPTION
Bug fixed with app intercept because of impl update in wg operator. 
As device is now namespace scoped, so no need of wg account name.