### PR TITLE
Fix/project and environment

### DIFF
--- a/apis/crds/v1/managedresource_types.go
+++ b/apis/crds/v1/managedresource_types.go
@@ -22,13 +22,14 @@ type mresKind struct {
 }
 
 type MresResourceTemplate struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:",inline" graphql:"children-required"`
 	MsvcRef         MsvcNamedRef                    `json:"msvcRef"`
 	Spec            map[string]apiextensionsv1.JSON `json:"spec"`
 }
 
 // ManagedResourceSpec defines the desired state of ManagedResource
 type ManagedResourceSpec struct {
+	ResourceName     string               `json:"resourceName,omitempty"`
 	ResourceTemplate MresResourceTemplate `json:"resourceTemplate"`
 }
 

--- a/apis/mongodb.msvc/v1/database_types.go
+++ b/apis/mongodb.msvc/v1/database_types.go
@@ -14,7 +14,7 @@ type DatabaseOutput struct {
 // DatabaseSpec defines the desired state of Database
 type DatabaseSpec struct {
 	MsvcRef      ct.MsvcRef     `json:"msvcRef"`
-	ResourceName string         `json:"resourceName"`
+	ResourceName string         `json:"resourceName,omitempty"`
 	Output       DatabaseOutput `json:"output,omitempty" graphql:"noinput"`
 }
 

--- a/apps/coredns/.dockerignore
+++ b/apps/coredns/.dockerignore
@@ -1,4 +1,4 @@
 **
 !bin
 !main.go
-!Corefile
+!examples

--- a/apps/coredns/Containerfile
+++ b/apps/coredns/Containerfile
@@ -1,5 +1,5 @@
 FROM docker.io/rancher/mirrored-coredns-coredns:1.10.1
-COPY ./Corefile /tmp/Corefile
+COPY ./examples/Corefile /tmp/Corefile
 WORKDIR /app
 COPY ./bin/kl-coredns /app/kl-coredns
 EXPOSE 53 53/udp

--- a/apps/coredns/Taskfile.yml
+++ b/apps/coredns/Taskfile.yml
@@ -7,8 +7,11 @@ tasks:
   build:
     env:
       CGO_ENABLED: 0
+    vars:
+      BuiltAt:
+        sh: date | sed 's/\s/_/g'
     cmds:
-      - go build -ldflags="-s -w" -o ./bin/kl-coredns .
+      - go build -ldflags="-s -w -X github.com/kloudlite/operator/common.BuiltAt='{{.BuiltAt}}'" -o ./bin/kl-coredns .
 
   container:build:
     cmds:

--- a/apps/coredns/main.go
+++ b/apps/coredns/main.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+
+	"github.com/kloudlite/operator/common"
 )
 
 var debug bool
@@ -71,6 +73,10 @@ func main() {
 	go runCoreDNS(ctx, newCorefilePath)
 
 	sm := http.NewServeMux()
+	sm.HandleFunc("/healthy", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	})
+
 	sm.HandleFunc("/resync", func(w http.ResponseWriter, r *http.Request) {
 		log.Println("resyncing corefile")
 		b, err := io.ReadAll(r.Body)
@@ -92,6 +98,9 @@ func main() {
 		w.WriteHeader(200)
 	})
 
+	common.PrintReadyBanner()
+
+	log.Printf("use /healthy to check, if server is reachable")
 	log.Printf("http server is starting on %s", addr)
 
 	http.ListenAndServe(addr, sm)

--- a/config/crd/bases/crds.kloudlite.io_managedresources.yaml
+++ b/config/crd/bases/crds.kloudlite.io_managedresources.yaml
@@ -51,6 +51,8 @@ spec:
           spec:
             description: ManagedResourceSpec defines the desired state of ManagedResource
             properties:
+              resourceName:
+                type: string
               resourceTemplate:
                 properties:
                   apiVersion:

--- a/config/crd/bases/mongodb.msvc.kloudlite.io_databases.yaml
+++ b/config/crd/bases/mongodb.msvc.kloudlite.io_databases.yaml
@@ -88,7 +88,6 @@ spec:
                 type: string
             required:
             - msvcRef
-            - resourceName
             type: object
           status:
             properties:

--- a/operators/msvc-mongo/internal/templates/helm-mongodb-cluster.yml.tpl
+++ b/operators/msvc-mongo/internal/templates/helm-mongodb-cluster.yml.tpl
@@ -27,10 +27,8 @@ metadata:
   annotations: {{$annotations | toYAML | nindent 4}}
   ownerReferences: {{$ownerRefs | toYAML | nindent 4}}
 spec:
-  chartRepo:
-    name: bitnami
-    url: https://charts.bitnami.com/bitnami
-  chartName: bitnami/mongodb
+  chartRepoURL: https://charts.bitnami.com/bitnami
+  chartName: mongodb
   chartVersion: 14.3.1
 
   values:

--- a/operators/msvc-mongo/internal/templates/helm-mongodb-standalone.yml.tpl
+++ b/operators/msvc-mongo/internal/templates/helm-mongodb-standalone.yml.tpl
@@ -27,11 +27,9 @@ metadata:
   annotations: {{$annotations | toYAML | nindent 4}}
   ownerReferences: {{ $ownerRefs | toYAML | nindent 4 }}
 spec:
-  chartRepo:
-    url: https://charts.bitnami.com/bitnami
-    name: bitnami
+  chartRepoURL: https://charts.bitnami.com/bitnami
   chartVersion: 13.18.1
-  chartName: bitnami/mongodb
+  chartName: mongodb
 
   values:
     # source: https://github.com/bitnami/charts/tree/main/bitnami/mongodb/

--- a/operators/msvc-n-mres/internal/msvc/msvc-controller.go
+++ b/operators/msvc-n-mres/internal/msvc/msvc-controller.go
@@ -86,6 +86,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return step.ReconcilerResponse()
 	}
 
+	if step := r.ensureRealMsvcCreated(req); !step.ShouldProceed() {
+		return step.ReconcilerResponse()
+	}
+
 	if step := r.ensureRealMsvcReady(req); !step.ShouldProceed() {
 		return step.ReconcilerResponse()
 	}

--- a/operators/project/internal/controllers/environment/helpers.go
+++ b/operators/project/internal/controllers/environment/helpers.go
@@ -1,0 +1,18 @@
+package environment
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func findResourceBelongingToEnvironment(ctx context.Context, kclient client.Client, resources client.ObjectList, envTargetNamespace string) error {
+	if err := kclient.List(ctx, resources, &client.ListOptions{
+		Namespace: envTargetNamespace,
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+

--- a/operators/routers/internal/controllers/router/controller.go
+++ b/operators/routers/internal/controllers/router/controller.go
@@ -253,7 +253,7 @@ func (r *Reconciler) parseAndExtractDomains(req *rApi.Request[*crdsv1.Router]) (
 
 	wcdMap := make(map[string]bool, cap(wcDomains))
 
-	if obj.Spec.Https.Enabled {
+	if obj.Spec.Https != nil && obj.Spec.Https.Enabled {
 		issuerName := obj.Spec.Https.ClusterIssuer
 		if issuerName == "" {
 			issuerName = r.Env.DefaultClusterIssuer

--- a/operators/wireguard/internal/env/env.go
+++ b/operators/wireguard/internal/env/env.go
@@ -18,6 +18,7 @@ type Env struct {
 	ClusterInternalDns  string `env:"CLUSTER_INTERNAL_DNS" default:"cluster.local"`
 	DeviceInfoNamespace string `env:"DEVICE_INFO_NAMESPACE" default:"device-info"`
 
+	DefaultIngressClass    string `env:"DEFAULT_INGRESS_CLASS" required:"true"`
 	EnvironmentIngressName string `env:"ENVIRONMENT_INGRESS_NAME" default:"env-ingress"`
 }
 

--- a/pkg/functions/main.go
+++ b/pkg/functions/main.go
@@ -203,3 +203,20 @@ func Filter[T comparable](from []T, items []T, filterFunc func(fromItem T, targe
 	}
 	return result
 }
+
+func JsonConvert[T any](from any) (T, error) {
+	var to T
+	if from == nil {
+		return to, nil
+	}
+
+	b, err := json.Marshal(from)
+	if err != nil {
+		return to, err
+	}
+
+	if err := json.Unmarshal(b, &to); err != nil {
+		return to, errors.NewE(err)
+	}
+	return to, nil
+}

--- a/pkg/functions/operator-helpers.go
+++ b/pkg/functions/operator-helpers.go
@@ -3,8 +3,13 @@ package functions
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
+
+	"github.com/kloudlite/operator/pkg/logging"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -142,4 +147,44 @@ func FilterObservabilityAnnotations(obj client.Object) map[string]string {
 		}
 	}
 	return m
+}
+
+func DeleteAndWait(ctx context.Context, logger logging.Logger, kcli client.Client, resources ...client.Object) error {
+	deletionStatus := make(map[string]bool)
+
+	for i := range resources {
+		resourceRef := fmt.Sprintf("resource (%s/%s) (gvk: %s)", resources[i].GetNamespace(), resources[i].GetName(), resources[i].GetObjectKind().GroupVersionKind().String())
+
+		deletionStatus[resourceRef] = false
+
+		if err := kcli.Get(ctx, client.ObjectKeyFromObject(resources[i]), resources[i]); err != nil {
+			if apiErrors.IsNotFound(err) {
+				deletionStatus[resourceRef] = true
+				continue
+			}
+			return err
+		}
+
+		if resources[i].GetDeletionTimestamp() == nil {
+			logger.Infof("deleting %s", resourceRef)
+
+			if err := kcli.Delete(ctx, resources[i], &client.DeleteOptions{
+				GracePeriodSeconds: New(int64(30)),
+				PropagationPolicy:  New(metav1.DeletePropagationForeground),
+			}); err != nil {
+				if !apiErrors.IsNotFound(err) {
+					return err
+				}
+				return fmt.Errorf("waiting for deletion for %s", resourceRef)
+			}
+		}
+	}
+
+	for k, v := range deletionStatus {
+		if !v {
+			return fmt.Errorf("waiting for (%s) to be removed from k8s", k)
+		}
+	}
+
+	return nil
 }

--- a/pkg/operator/main.go
+++ b/pkg/operator/main.go
@@ -29,7 +29,7 @@ type Check struct {
 
 // +kubebuilder:object:generate=true
 type ResourceRef struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:",inline" graphql:"children-required"`
 	Namespace       string `json:"namespace"`
 	Name            string `json:"name"`
 }


### PR DESCRIPTION
### Description

This PR introduces several feature enhancements and fixes across different components of the application.

**Wireguard Operator**
- The `operators/wireguard` component now updates device local DNS resolution when there's an environment change. This ensures that DNS resolution remains accurate and up-to-date.

**pkg/kubectl**
- The `ApplyYAML` utility has been updated to remove the `kloudlite.io/last-applied` annotation before creating a new `last-applied` value. This fixes issues related to large annotation values that were occurring previously.

**CoreDNS**
- In the `apps/coredns` component, a new `/healthy` route has been added. Additionally, a Kloudlite banner has been included.

**Managed Resource Operator**
- Every managed resource now includes a `.spec.resourceName` field. This field is automatically populated by the operator if it's left empty. All real resources are built based on this `.spec.resourceName`.

**Project Operator**
- Fixes have been made in the `operators/project` component to address project and environment deletion issues.

These changes collectively enhance the functionality and reliability of various parts of the application.

[Additional context or details if necessary.]
