### PR TITLE
Fix/nodepool buildrun controller

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -231,7 +231,7 @@ tasks:
         binpath="manager"
         task build Out="$tdir/$binpath" CWD="$PWD"
         podman buildx build -f Containerfile.local -t {{.Image}} . --build-context local-builder="$tdir" --build-arg binpath="$binpath"
-        podman push {{.Image}}
+        # podman push {{.Image}}
 
 
 

--- a/cmd/platform-operator/Containerfile.local
+++ b/cmd/platform-operator/Containerfile.local
@@ -6,8 +6,8 @@
 FROM alpine:3.16
 RUN apk add bash
 
-COPY --from=docker.io/vectorized/redpanda:v22.1.6 /usr/bin/rpk /usr/local/bin/rpk
-COPY --from=docker.io/vectorized/redpanda:v22.1.6 /opt/redpanda/libexec/rpk /opt/redpanda/libexec/rpk
+# COPY --from=docker.io/vectorized/redpanda:v22.1.6 /usr/bin/rpk /usr/local/bin/rpk
+# COPY --from=docker.io/vectorized/redpanda:v22.1.6 /opt/redpanda/libexec/rpk /opt/redpanda/libexec/rpk
 
 ARG binpath
 COPY --from=local-builder ${binpath} /manager

--- a/cmd/platform-operator/main.go
+++ b/cmd/platform-operator/main.go
@@ -6,9 +6,10 @@ import (
 	clusters "github.com/kloudlite/operator/operators/clusters/controller"
 	helmCharts "github.com/kloudlite/operator/operators/helm-charts/controller"
 	msvcMongo "github.com/kloudlite/operator/operators/msvc-mongo/controller"
+	nodepool "github.com/kloudlite/operator/operators/nodepool/controller"
 	project "github.com/kloudlite/operator/operators/project/controller"
 	routers "github.com/kloudlite/operator/operators/routers/controller"
-	// routers "github.com/kloudlite/operator/operators/routers/controller"
+	wireguard "github.com/kloudlite/operator/operators/wireguard/controller"
 )
 
 func main() {
@@ -25,6 +26,8 @@ func main() {
 
 	// kloudlite cluster management
 	clusters.RegisterInto(mgr)
+	nodepool.RegisterInto(mgr)
+	wireguard.RegisterInto(mgr)
 
 	mgr.Start()
 }

--- a/operators/distribution/internal/env/env.go
+++ b/operators/distribution/internal/env/env.go
@@ -10,7 +10,7 @@ type Env struct {
 	ReconcilePeriod         time.Duration `env:"RECONCILE_PERIOD"`
 	MaxConcurrentReconciles int           `env:"MAX_CONCURRENT_RECONCILES"`
 
-	BuildNameSpace string `env:"BUILD_NAMESPACE" required:"true"`
+	BuildNamespace string `env:"BUILD_NAMESPACE" required:"true"`
 	IsDev          bool
 }
 

--- a/operators/distribution/internal/templates/build-job.yml.tpl
+++ b/operators/distribution/internal/templates/build-job.yml.tpl
@@ -22,7 +22,7 @@ metadata:
   namespace: {{ $namespace }}
   labels: {{ $labels | toJson }}
   annotations: {{ $annotations | toJson }}
-  ownerReferences: {{ $ownerRefs| toJson}}
+  {{- /* ownerReferences: {{ $ownerRefs| toJson}} */}}
 spec:
   backoffLimit: 0
   suspend: false

--- a/operators/nodepool/internal/templates/embed.go
+++ b/operators/nodepool/internal/templates/embed.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"embed"
+	"path/filepath"
 
 	"github.com/kloudlite/operator/pkg/templates"
 )
@@ -9,8 +10,15 @@ import (
 //go:embed *
 var templatesDir embed.FS
 
-func ReadNodepoolJobTemplate() ([]byte, error) {
-	return templatesDir.ReadFile("nodepool-job.yml.tpl")
+type templateFile string
+
+const (
+	NodepoolJobNamespaceRBAC templateFile = "./nodepool-job-namespace-rbac.yml.tpl"
+	NodepoolJob              templateFile = "./nodepool-job.yml.tpl"
+)
+
+func Read(t templateFile) ([]byte, error) {
+	return templatesDir.ReadFile(filepath.Join(string(t)))
 }
 
 var ParseBytes = templates.ParseBytes

--- a/operators/nodepool/internal/templates/nodepool-job-namespace-rbac.yml.tpl
+++ b/operators/nodepool/internal/templates/nodepool-job-namespace-rbac.yml.tpl
@@ -1,0 +1,31 @@
+{{- $namespace := get . "namespace" }}
+
+{{- $sa := "kloudlite-jobs" }}
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{$namespace}}
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{$sa}}"
+  namespace: {{$namespace}}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{$namespace}}-{{$sa}}-rb
+subjects:
+  - kind: ServiceAccount
+    name: {{$sa}}
+    namespace: {{$namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: "ClusterRole"
+  name: cluster-admin
+---

--- a/operators/project/internal/controllers/project/controller.go
+++ b/operators/project/internal/controllers/project/controller.go
@@ -134,7 +134,7 @@ func (r *Reconciler) finalize(req *rApi.Request[*crdsv1.Project]) stepResult.Res
 
 	projectMsvcs := make([]client.Object, len(projectMsvcList.Items))
 	for i := range projectMsvcList.Items {
-		envs[i] = &projectMsvcList.Items[i]
+		projectMsvcs[i] = &projectMsvcList.Items[i]
 	}
 
 	if err := fn.DeleteAndWait(ctx, r.logger, r.Client, projectMsvcs...); err != nil {


### PR DESCRIPTION
### PR Description

**Project Controller and Wireguard Controller**
- The project controller has undergone crucial fixes to address issues in its functionality. Additionally, the wireguard controller is now available in the `cmd/platform-operator`. These changes improve the overall reliability and performance of project-related operations.

**Nodepool Controller**
- The nodepool controller has received important updates, including the ability to create a job namespace and its associated RBACs if they do not already exist. This enhancement streamlines the management of nodepools and their related resources.

**Distribution Controller**
- The distribution controller has been optimized by updating the buildrun template. These changes aim to reduce unnecessary reconciliations, resulting in improved resource utilization and responsiveness.
