### PR TITLE
Fix/rollout restart and msvc label propagation

### DIFF
--- a/operators/msvc-mongo/internal/controllers/cluster-service/controller.go
+++ b/operators/msvc-mongo/internal/controllers/cluster-service/controller.go
@@ -267,11 +267,9 @@ func (r *Reconciler) reconHelm(req *rApi.Request[*mongodbMsvcv1.ClusterService])
 	}
 
 	b, err := templates.ParseBytes(r.templateHelmMongoDBCluster, map[string]any{
-		"name":      obj.Name,
-		"namespace": obj.Namespace,
-		"labels": map[string]string{
-			constants.MsvcNameKey: obj.Name,
-		},
+		"name":       obj.Name,
+		"namespace":  obj.Namespace,
+		"labels":     obj.GetLabels(),
 		"owner-refs": []metav1.OwnerReference{fn.AsOwner(obj, true)},
 
 		"storage-class": obj.Spec.Resources.Storage.StorageClass,

--- a/operators/msvc-mongo/internal/controllers/standalone-service/controller.go
+++ b/operators/msvc-mongo/internal/controllers/standalone-service/controller.go
@@ -267,11 +267,9 @@ func (r *Reconciler) reconHelm(req *rApi.Request[*mongodbMsvcv1.StandaloneServic
 
 	// TODO (nxtcoder17): when increasing pvc volume size, we can not trigger helm update, as it complains about forbidden field
 	b, err := templates.ParseBytes(r.templateHelmMongoDB, map[string]any{
-		"name":      obj.Name,
-		"namespace": obj.Namespace,
-		"labels": map[string]string{
-			constants.MsvcNameKey: obj.Name,
-		},
+		"name":          obj.Name,
+		"namespace":     obj.Namespace,
+		"labels":        obj.GetLabels(),
 		"owner-refs":    []metav1.OwnerReference{fn.AsOwner(obj)},
 		"node-selector": obj.Spec.NodeSelector,
 

--- a/operators/msvc-n-mres/internal/msvc/msvc-controller.go
+++ b/operators/msvc-n-mres/internal/msvc/msvc-controller.go
@@ -122,7 +122,7 @@ func (r *Reconciler) ensureRealMsvcCreated(req *rApi.Request[*crdsv1.ManagedServ
 
 		"name":       obj.Name,
 		"namespace":  obj.Namespace,
-		"labels":     obj.GetEnsuredLabels(),
+		"labels":     obj.GetLabels(),
 		"owner-refs": []metav1.OwnerReference{fn.AsOwner(obj, true)},
 
 		"service-template-spec": obj.Spec.ServiceTemplate.Spec,

--- a/operators/msvc-n-mres/internal/project-msvc/project-msvc.controller.go
+++ b/operators/msvc-n-mres/internal/project-msvc/project-msvc.controller.go
@@ -195,8 +195,10 @@ func (r *Reconciler) ensureMsvcCreatedNReady(req *rApi.Request[*crdsv1.ProjectMa
 		for k, v := range m {
 			fn.MapSet(&msvc.Annotations, k, v)
 		}
-		fn.MapSet(&msvc.Labels, constants.ProjectManagedServiceRefKey, fmt.Sprintf("%s_%s", obj.Namespace, obj.Name))
+		labels := obj.GetLabels()
+		fn.MapSet(&labels, constants.ProjectManagedServiceRefKey, fmt.Sprintf("%s_%s", obj.Namespace, obj.Name))
 
+		msvc.SetLabels(labels)
 		msvc.Spec = obj.Spec.MSVCSpec
 		return nil
 	}); err != nil {

--- a/operators/resource-watcher/internal/controllers/watch-and-update/controller.go
+++ b/operators/resource-watcher/internal/controllers/watch-and-update/controller.go
@@ -67,6 +67,10 @@ func (r *Reconciler) dispatchEvent(ctx context.Context, obj *unstructured.Unstru
 		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
 
+	ann := obj.GetAnnotations()
+	delete(ann, constants.LastAppliedKey)
+	obj.SetAnnotations(ann)
+
 	gvk := newGVK(obj.GetAPIVersion(), obj.GetKind())
 
 	switch gvk.String() {
@@ -260,9 +264,7 @@ func (r *Reconciler) SendResourceEvents(ctx context.Context, obj *unstructured.U
 func (r *Reconciler) Reconcile(ctx context.Context, oReq ctrl.Request) (ctrl.Result, error) {
 	if r.MsgSender == nil {
 		r.logger.Infof("message-sender is nil")
-		return ctrl.Result{
-			// RequeueAfter: 2 *time.Second,
-		}, errors.New("waiting for message sender to be initialized")
+		return ctrl.Result{}, errors.New("waiting for message sender to be initialized")
 	}
 
 	var wName types.WrappedName

--- a/pkg/kubectl/without-kubectl.go
+++ b/pkg/kubectl/without-kubectl.go
@@ -356,6 +356,10 @@ const (
 	StatefulSet Restartable = "statefulset"
 )
 
+func (r Restartable) String() string {
+	return string(r)
+}
+
 func (yc *yamlClient) RolloutRestart(ctx context.Context, kind Restartable, namespace string, labels map[string]string) error {
 	switch kind {
 	case Deployment:
@@ -372,7 +376,7 @@ func (yc *yamlClient) RolloutRestart(ctx context.Context, kind Restartable, name
 				if d.Annotations == nil {
 					d.Annotations = map[string]string{}
 				}
-				d.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+				d.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 				if _, err := yc.k8sClient.AppsV1().Deployments(namespace).Update(ctx, &d, metav1.UpdateOptions{}); err != nil {
 					return err
 				}
@@ -392,7 +396,7 @@ func (yc *yamlClient) RolloutRestart(ctx context.Context, kind Restartable, name
 				if d.Annotations == nil {
 					d.Annotations = map[string]string{}
 				}
-				d.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+				d.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 				if _, err := yc.k8sClient.AppsV1().StatefulSets(namespace).Update(ctx, &d, metav1.UpdateOptions{}); err != nil {
 					return err
 				}


### PR DESCRIPTION
### PR Description

**MSVC Controller**
- The MSVC controller has been updated to fix label propagation to pods. This fix ensures that labels from `ProjectManagedService` are correctly propagated to the real pods. This propagation is essential for restarting `StatefulSet` instances created by these pods.

**Resource Watcher Operator**
- The Resource Watcher Operator has been improved by removing the `kloudlite.io/last-applied` annotation from resources before dispatching them to the message office. This optimization helps ensure that the resources are correctly handled in the application.

**Kubectl Package**
- The `pkg/kubectl` package has received a fix for the `RolloutRestart` function in YamlClient. This fix addresses issues related to rolling restarts, enhancing the stability and reliability of the rollout process.


