### PR TITLE
Fix/controller updates

### DIFF
--- a/.github/workflows/build-operators.yml
+++ b/.github/workflows/build-operators.yml
@@ -13,7 +13,6 @@ on:
       - ".github/workflows/**"
       - "apis/**/*.go"
 
-
 permissions:
   contents: read
   packages: write
@@ -26,12 +25,12 @@ jobs:
           - platform
           - agent
           - wireguard
+          - helm-charts
           # - resource-watcher
           # - account
           # - app
           # - clusters
           # - distribution
-          # - helm-charts
           # - msvc-elasticsearch
           # - msvc-influx
           # - msvc-mongo
@@ -45,7 +44,7 @@ jobs:
           # - project
           # - resource-watcher
           # - routers
-          
+
         include:
           - name: platform
             buildDir: cmd/platform-operator
@@ -53,6 +52,8 @@ jobs:
             buildDir: cmd/agent-operator
           - name: wireguard
             buildDir: operators/wireguard
+          - name: helm-charts
+            buildDir: operators/helm-charts
           # - name: resource-watcher
           #   buildDir: operators/resource-watcher
           # - name: account
@@ -63,8 +64,6 @@ jobs:
           #   buildDir: operators/clusters
           # - name: distribution
           #   buildDir: operators/distribution
-          # - name: helm-charts
-          #   buildDir: operators/helm-charts
           # - name: msvc-elasticsearch
           #   buildDir: operators/msvc-elasticsearch
           # - name: msvc-influx
@@ -91,7 +90,6 @@ jobs:
           #   buildDir: operators/resource-watcher
           # - name: routers
           #   buildDir: operators/routers
-          
     runs-on: ubuntu-latest
     name: Deploy to Docker Image
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- router controller now adds annotation `nginx.ingress.kubernetes.io/from-to-www-redirect: "true"` to all the ingress resources, by default
+## [v1.0.5] - 2024-01-26
 
-## [1.0.5] - 2024-01-26
-- 
+### Added
+
+- router controller now adds annotation `nginx.ingress.kubernetes.io/from-to-www-redirect: "true"` to all the ingress resources, by default
+- helmchart CR, now has `.spec.releaseName` optional field to have a different release name than `.metadata.name`.
+
+[v1.0.5]: https://github.com/kloudlite/operator/compare/master...release-1.0.5

--- a/apis/clusters/v1/nodepool_types.go
+++ b/apis/clusters/v1/nodepool_types.go
@@ -49,15 +49,8 @@ type AWSNodePoolConfig struct {
 }
 
 type InfrastuctureAsCode struct {
-	StateS3BucketName     string `json:"stateS3BucketName"`
-	StateS3BucketRegion   string `json:"stateS3BucketRegion"`
-	StateS3BucketFilePath string `json:"stateS3BucketFilePath"`
-
 	CloudProviderAccessKey ct.SecretKeyRef `json:"cloudProviderAccessKey"`
 	CloudProviderSecretKey ct.SecretKeyRef `json:"cloudProviderSecretKey"`
-
-	JobName      string `json:"jobName,omitempty"`
-	JobNamespace string `json:"jobNamespace,omitempty"`
 }
 
 type OperatorVars struct {
@@ -85,6 +78,7 @@ type NodePoolSpec struct {
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:JSONPath=".metadata.annotations.nodepool-min-max",name=Min/Max,type=string
 // +kubebuilder:printcolumn:JSONPath=".status.lastReconcileTime",name=Last_Reconciled_At,type=date
+// +kubebuilder:printcolumn:JSONPath=".metadata.annotations.kloudlite\\.io\\/nodepool\\.job-ref",name=JobRef,type=string
 // +kubebuilder:printcolumn:JSONPath=".metadata.annotations.kloudlite\\.io\\/resource\\.ready",name=Ready,type=string
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
 

--- a/apis/crds/v1/helmchart_types.go
+++ b/apis/crds/v1/helmchart_types.go
@@ -24,6 +24,8 @@ type HelmChartSpec struct {
 
 	ChartName string `json:"chartName"`
 
+	ReleaseName string `json:"releaseName,omitempty" graphql:"noinput"`
+
 	JobVars JobVars `json:"jobVars,omitempty"`
 
 	PreInstall  string `json:"preInstall,omitempty"`

--- a/apis/crds/v1/project_types.go
+++ b/apis/crds/v1/project_types.go
@@ -15,10 +15,9 @@ type ProjectSpec struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:printcolumn:JSONPath=".spec.accountName",name=AccountName,type=string
-// +kubebuilder:printcolumn:JSONPath=".spec.clusterName",name=ClusterName,type=string
 // +kubebuilder:printcolumn:JSONPath=".spec.targetNamespace",name="target-namespace",type=string
-// +kubebuilder:printcolumn:JSONPath=".status.isReady",name=Ready,type=boolean
+// +kubebuilder:printcolumn:JSONPath=".status.lastReconcileTime",name=Last_Reconciled_At,type=date
+// +kubebuilder:printcolumn:JSONPath=".metadata.annotations.kloudlite\\.io\\/resource\\.ready",name=Ready,type=string
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
 
 // Project is the Schema for the projects API

--- a/apis/mongodb.msvc/v1/standaloneservice_types.go
+++ b/apis/mongodb.msvc/v1/standaloneservice_types.go
@@ -27,9 +27,8 @@ type StandaloneServiceSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".spec.region"
-// +kubebuilder:printcolumn:name="ReplicaCount",type="integer",JSONPath=".spec.replicaCount"
-// +kubebuilder:printcolumn:JSONPath=".status.isReady",name=Ready,type=boolean
+// +kubebuilder:printcolumn:JSONPath=".status.lastReconcileTime",name=Last_Reconciled_At,type=date
+// +kubebuilder:printcolumn:JSONPath=".metadata.annotations.kloudlite\\.io\\/resource\\.ready",name=Ready,type=string
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
 
 // StandaloneService is the Schema for the standaloneservices API

--- a/config/crd/bases/clusters.kloudlite.io_accounts3buckets.yaml
+++ b/config/crd/bases/clusters.kloudlite.io_accounts3buckets.yaml
@@ -94,6 +94,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/clusters.kloudlite.io_clusters.yaml
+++ b/config/crd/bases/clusters.kloudlite.io_clusters.yaml
@@ -298,6 +298,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/clusters.kloudlite.io_nodepools.yaml
+++ b/config/crd/bases/clusters.kloudlite.io_nodepools.yaml
@@ -22,6 +22,9 @@ spec:
     - jsonPath: .status.lastReconcileTime
       name: Last_Reconciled_At
       type: date
+    - jsonPath: .metadata.annotations.kloudlite\.io\/nodepool\.job-ref
+      name: JobRef
+      type: string
     - jsonPath: .metadata.annotations.kloudlite\.io\/resource\.ready
       name: Ready
       type: string
@@ -178,22 +181,9 @@ spec:
                     - key
                     - name
                     type: object
-                  jobName:
-                    type: string
-                  jobNamespace:
-                    type: string
-                  stateS3BucketFilePath:
-                    type: string
-                  stateS3BucketName:
-                    type: string
-                  stateS3BucketRegion:
-                    type: string
                 required:
                 - cloudProviderAccessKey
                 - cloudProviderSecretKey
-                - stateS3BucketFilePath
-                - stateS3BucketName
-                - stateS3BucketRegion
                 type: object
               maxCount:
                 minimum: 0
@@ -246,6 +236,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/clusters.kloudlite.io_nodes.yaml
+++ b/config/crd/bases/clusters.kloudlite.io_nodes.yaml
@@ -58,6 +58,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/crds.kloudlite.io_accounts.yaml
+++ b/config/crd/bases/crds.kloudlite.io_accounts.yaml
@@ -56,6 +56,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/crds.kloudlite.io_apps.yaml
+++ b/config/crd/bases/crds.kloudlite.io_apps.yaml
@@ -357,6 +357,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/crds.kloudlite.io_clustermanagedservices.yaml
+++ b/config/crd/bases/crds.kloudlite.io_clustermanagedservices.yaml
@@ -85,6 +85,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/crds.kloudlite.io_environments.yaml
+++ b/config/crd/bases/crds.kloudlite.io_environments.yaml
@@ -79,6 +79,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/crds.kloudlite.io_helmcharts.yaml
+++ b/config/crd/bases/crds.kloudlite.io_helmcharts.yaml
@@ -989,6 +989,8 @@ spec:
                 type: string
               preUninstall:
                 type: string
+              releaseName:
+                type: string
               values:
                 additionalProperties:
                   x-kubernetes-preserve-unknown-fields: true
@@ -1009,6 +1011,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/crds.kloudlite.io_managedresources.yaml
+++ b/config/crd/bases/crds.kloudlite.io_managedresources.yaml
@@ -103,6 +103,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/crds.kloudlite.io_managedservices.yaml
+++ b/config/crd/bases/crds.kloudlite.io_managedservices.yaml
@@ -78,6 +78,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/crds.kloudlite.io_projectmanagedservices.yaml
+++ b/config/crd/bases/crds.kloudlite.io_projectmanagedservices.yaml
@@ -85,6 +85,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/crds.kloudlite.io_projects.yaml
+++ b/config/crd/bases/crds.kloudlite.io_projects.yaml
@@ -16,18 +16,15 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.accountName
-      name: AccountName
-      type: string
-    - jsonPath: .spec.clusterName
-      name: ClusterName
-      type: string
     - jsonPath: .spec.targetNamespace
       name: target-namespace
       type: string
-    - jsonPath: .status.isReady
+    - jsonPath: .status.lastReconcileTime
+      name: Last_Reconciled_At
+      type: date
+    - jsonPath: .metadata.annotations.kloudlite\.io\/resource\.ready
       name: Ready
-      type: boolean
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -65,6 +62,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/crds.kloudlite.io_routers.yaml
+++ b/config/crd/bases/crds.kloudlite.io_routers.yaml
@@ -141,6 +141,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/csi.kloudlite.io_drivers.yaml
+++ b/config/crd/bases/csi.kloudlite.io_drivers.yaml
@@ -101,6 +101,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/distribution.kloudlite.io_buildruns.yaml
+++ b/config/crd/bases/distribution.kloudlite.io_buildruns.yaml
@@ -132,6 +132,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/elasticsearch.msvc.kloudlite.io_kibanas.yaml
+++ b/config/crd/bases/elasticsearch.msvc.kloudlite.io_kibanas.yaml
@@ -117,6 +117,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/elasticsearch.msvc.kloudlite.io_services.yaml
+++ b/config/crd/bases/elasticsearch.msvc.kloudlite.io_services.yaml
@@ -152,6 +152,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/influxdb.msvc.kloudlite.io_buckets.yaml
+++ b/config/crd/bases/influxdb.msvc.kloudlite.io_buckets.yaml
@@ -86,6 +86,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/influxdb.msvc.kloudlite.io_services.yaml
+++ b/config/crd/bases/influxdb.msvc.kloudlite.io_services.yaml
@@ -157,6 +157,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/mongodb.msvc.kloudlite.io_clusterservices.yaml
+++ b/config/crd/bases/mongodb.msvc.kloudlite.io_clusterservices.yaml
@@ -335,6 +335,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/mongodb.msvc.kloudlite.io_databases.yaml
+++ b/config/crd/bases/mongodb.msvc.kloudlite.io_databases.yaml
@@ -98,6 +98,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/mongodb.msvc.kloudlite.io_standaloneservices.yaml
+++ b/config/crd/bases/mongodb.msvc.kloudlite.io_standaloneservices.yaml
@@ -16,15 +16,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.region
-      name: Region
-      type: string
-    - jsonPath: .spec.replicaCount
-      name: ReplicaCount
-      type: integer
-    - jsonPath: .status.isReady
+    - jsonPath: .status.lastReconcileTime
+      name: Last_Reconciled_At
+      type: date
+    - jsonPath: .metadata.annotations.kloudlite\.io\/resource\.ready
       name: Ready
-      type: boolean
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -167,6 +164,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/mysql.msvc.kloudlite.io_clusterservices.yaml
+++ b/config/crd/bases/mysql.msvc.kloudlite.io_clusterservices.yaml
@@ -143,6 +143,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/mysql.msvc.kloudlite.io_databases.yaml
+++ b/config/crd/bases/mysql.msvc.kloudlite.io_databases.yaml
@@ -79,6 +79,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/mysql.msvc.kloudlite.io_standaloneservices.yaml
+++ b/config/crd/bases/mysql.msvc.kloudlite.io_standaloneservices.yaml
@@ -149,6 +149,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/neo4j.msvc.kloudlite.io_standaloneservices.yaml
+++ b/config/crd/bases/neo4j.msvc.kloudlite.io_standaloneservices.yaml
@@ -143,6 +143,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/opensearch.msvc.kloudlite.io_services.yaml
+++ b/config/crd/bases/opensearch.msvc.kloudlite.io_services.yaml
@@ -46,6 +46,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/redis.msvc.kloudlite.io_aclaccounts.yaml
+++ b/config/crd/bases/redis.msvc.kloudlite.io_aclaccounts.yaml
@@ -80,6 +80,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/redis.msvc.kloudlite.io_aclconfigmaps.yaml
+++ b/config/crd/bases/redis.msvc.kloudlite.io_aclconfigmaps.yaml
@@ -56,6 +56,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/redis.msvc.kloudlite.io_standaloneservices.yaml
+++ b/config/crd/bases/redis.msvc.kloudlite.io_standaloneservices.yaml
@@ -145,6 +145,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/redpanda.msvc.kloudlite.io_aclusers.yaml
+++ b/config/crd/bases/redpanda.msvc.kloudlite.io_aclusers.yaml
@@ -70,6 +70,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/redpanda.msvc.kloudlite.io_admins.yaml
+++ b/config/crd/bases/redpanda.msvc.kloudlite.io_admins.yaml
@@ -80,6 +80,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/redpanda.msvc.kloudlite.io_services.yaml
+++ b/config/crd/bases/redpanda.msvc.kloudlite.io_services.yaml
@@ -121,6 +121,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/redpanda.msvc.kloudlite.io_topics.yaml
+++ b/config/crd/bases/redpanda.msvc.kloudlite.io_topics.yaml
@@ -59,6 +59,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/s3.aws.kloudlite.io_buckets.yaml
+++ b/config/crd/bases/s3.aws.kloudlite.io_buckets.yaml
@@ -53,6 +53,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/serverless.kloudlite.io_lambdas.yaml
+++ b/config/crd/bases/serverless.kloudlite.io_lambdas.yaml
@@ -293,6 +293,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/wireguard.kloudlite.io_devices.yaml
+++ b/config/crd/bases/wireguard.kloudlite.io_devices.yaml
@@ -88,6 +88,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/config/crd/bases/zookeeper.msvc.kloudlite.io_services.yaml
+++ b/config/crd/bases/zookeeper.msvc.kloudlite.io_services.yaml
@@ -142,6 +142,7 @@ spec:
                       format: int64
                       type: integer
                     message:
+                      description: State      State  `json:"state"`
                       type: string
                     status:
                       type: boolean

--- a/operators/clusters/controller/register.go
+++ b/operators/clusters/controller/register.go
@@ -8,7 +8,7 @@ import (
 
 	clustersv1 "github.com/kloudlite/operator/apis/clusters/v1"
 	"github.com/kloudlite/operator/operator"
-	account_s3_bucket "github.com/kloudlite/operator/operators/clusters/internal/controllers/account-s3-bucket"
+	// account_s3_bucket "github.com/kloudlite/operator/operators/clusters/internal/controllers/account-s3-bucket"
 	"github.com/kloudlite/operator/operators/clusters/internal/controllers/target"
 	"github.com/kloudlite/operator/operators/clusters/internal/env"
 	"github.com/kloudlite/operator/operators/resource-watcher/types"
@@ -104,6 +104,6 @@ func RegisterInto(mgr operator.Operator) {
 				return nil
 			},
 		},
-		&account_s3_bucket.Reconciler{Name: "clusters:account-s3-bucket", Env: ev},
+		// &account_s3_bucket.Reconciler{Name: "clusters:account-s3-bucket", Env: ev},
 	)
 }

--- a/operators/clusters/internal/env/env.go
+++ b/operators/clusters/internal/env/env.go
@@ -1,21 +1,14 @@
 package env
 
 import (
-	"time"
-
 	"github.com/codingconcepts/env"
 )
 
 type Env struct {
-	ReconcilePeriod         time.Duration `env:"RECONCILE_PERIOD"`
-	MaxConcurrentReconciles int           `env:"MAX_CONCURRENT_RECONCILES"`
+	MaxConcurrentReconciles int `env:"MAX_CONCURRENT_RECONCILES"`
 
 	CloudflareApiToken string `env:"CLOUDFLARE_API_TOKEN" required:"true"`
 	CloudflareZoneId   string `env:"CLOUDFLARE_ZONE_ID" required:"true"`
-
-	KlS3BucketName      string `env:"KL_S3_IAC_BUCKET_NAME" required:"true"`
-	KlS3BucketRegion    string `env:"KL_S3_IAC_BUCKET_REGION" required:"true"`
-	KlS3BucketDirectory string `env:"KL_S3_IAC_DIRECTORY" required:"true"`
 
 	KlAwsAccessKey string `env:"KL_AWS_ACCESS_KEY" required:"true"`
 	KlAwsSecretKey string `env:"KL_AWS_SECRET_KEY" required:"true"`

--- a/operators/clusters/internal/templates/rbac-for-cluster-job.yml.tpl
+++ b/operators/clusters/internal/templates/rbac-for-cluster-job.yml.tpl
@@ -16,7 +16,13 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get","create", "delete", "update", "patch"]
+  verbs: ["get", "list", "create", "delete", "update", "patch"]
+- apiGroups: 
+    - "coordination.k8s.io"
+  resources:
+    - "leases"
+  verbs: ["get", "list", "create", "delete", "update", "patch"]
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operators/msvc-mongo/examples/mongodb-cluster.yml
+++ b/operators/msvc-mongo/examples/mongodb-cluster.yml
@@ -1,20 +1,17 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: examples
----
 apiVersion: mongodb.msvc.kloudlite.io/v1
 kind: ClusterService
 metadata:
-  name: mongodb-cluster
-  namespace: examples
+  name: mongodb-cluster-test
+  namespace: default
 spec:
-  replicas: 3
+  replicas: 2
   resources:
     cpu:
       min: 300m
       max: 500m
-    memory: 500Mi
+    memory:
+      min: 500Mi
+      max: 500Mi
     storage:
       size: 1Gi
       storageClass: sc-xfs

--- a/operators/msvc-mongo/internal/controllers/database/controller.go
+++ b/operators/msvc-mongo/internal/controllers/database/controller.go
@@ -360,9 +360,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, logger logging.Logger) e
 	r.yamlClient = kubectl.NewYAMLClientOrDie(mgr.GetConfig(), kubectl.YAMLClientOpts{Logger: r.logger})
 
 	builder := ctrl.NewControllerManagedBy(mgr).For(&mongodbMsvcv1.Database{})
-	builder.WithOptions(controller.Options{
-		MaxConcurrentReconciles: r.Env.MaxConcurrentReconciles,
-	})
 	builder.Owns(&corev1.Secret{})
 
 	watchList := []client.Object{

--- a/operators/msvc-mongo/internal/templates/helm-mongodb-cluster.yml.tpl
+++ b/operators/msvc-mongo/internal/templates/helm-mongodb-cluster.yml.tpl
@@ -1,5 +1,8 @@
 {{- $name := get . "name" }} 
 {{- $namespace := get . "namespace" }} 
+
+{{- $releaseName := get . "release-name" }}
+
 {{- $labels := get . "labels" | default dict }} 
 {{- $annotations := get . "annotations" | default dict}}
 {{- $ownerRefs := get . "owner-refs" | default list }}
@@ -29,7 +32,11 @@ metadata:
 spec:
   chartRepoURL: https://charts.bitnami.com/bitnami
   chartName: mongodb
-  chartVersion: 14.3.1
+  chartVersion: 14.3.0
+
+  {{- if $releaseName }}
+  releaseName: {{$releaseName}}
+  {{- end }}
 
   values:
     # source: https://github.com/bitnami/charts/tree/main/bitnami/mongodb/
@@ -47,6 +54,8 @@ spec:
     replicaCount: {{ $replicaCount | int64 }}
     replicaSetName: rs
     replicaSetHostnames: true
+
+    commonLabels: {{$labels | toYAML | nindent 6}}
     podLabels: {{$labels | toYAML | nindent 6}}
 
     directoryPerDB: true

--- a/operators/nodepool/internal/env/env.go
+++ b/operators/nodepool/internal/env/env.go
@@ -10,11 +10,16 @@ type Env struct {
 	CloudProviderName   string `env:"CLOUD_PROVIDER_NAME" required:"true"`
 	CloudProviderRegion string `env:"CLOUD_PROVIDER_REGION" required:"true"`
 
+	JobsNamespace string `env:"JOBS_NAMESPACE" default:"kloudlite-jobs"`
+
+	AccountName string `env:"ACCOUNT_NAME" required:"true"` // required only for labelling nodepool nodes with it
+	ClusterName string `env:"CLUSTER_NAME" required:"true"` // required only for labelling nodepool nodes with it
+
 	K3sJoinToken        string `env:"K3S_JOIN_TOKEN" required:"true"`
 	K3sServerPublicHost string `env:"K3S_SERVER_PUBLIC_HOST" required:"true"`
 
-	KloudliteAccountName string `env:"KLOUDLITE_ACCOUNT_NAME" required:"true"`
-	KloudliteClusterName string `env:"KLOUDLITE_CLUSTER_NAME" required:"true"`
+	TFStateSecretNamespace string `env:"TF_STATE_SECRET_NAMESPACE" required:"true" default:"kloudlite"`
+	IACJobImage            string `env:"IAC_JOB_IMAGE" required:"true"`
 }
 
 func GetEnvOrDie() *Env {

--- a/pkg/functions/kubectl.go
+++ b/pkg/functions/kubectl.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"os/exec"
+	"strings"
 
 	"github.com/kloudlite/operator/pkg/logging"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,8 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kloudlite/operator/pkg/errors"
-
-	"strings"
 
 	"github.com/gobuffalo/flect"
 )
@@ -180,7 +179,7 @@ func AsOwner(r client.Object, controller ...bool) metav1.OwnerReference {
 		Name:       r.GetName(),
 		UID:        r.GetUID(),
 		Controller: &ctrler,
-		//BlockOwnerDeletion: New(false),
+		// BlockOwnerDeletion: New(false),
 		BlockOwnerDeletion: &ctrler,
 	}
 }
@@ -195,6 +194,10 @@ func IsOwner(obj client.Object, ownerRef metav1.OwnerReference) bool {
 		}
 	}
 	return false
+}
+
+func HasOwner(obj client.Object) bool {
+	return len(obj.GetOwnerReferences()) > 0
 }
 
 func ParseGVK(apiVersion string, kind string) schema.GroupVersionKind {

--- a/pkg/kubectl/without-kubectl.go
+++ b/pkg/kubectl/without-kubectl.go
@@ -102,6 +102,7 @@ func (yc *yamlClient) ApplyYAML(ctx context.Context, yamls ...[]byte) ([]rApi.Re
 		ann := obj.GetAnnotations()
 		delete(ann, constants.LastAppliedKey)
 		obj.SetAnnotations(ann)
+
 		if ann == nil {
 			ann = make(map[string]string)
 		}
@@ -168,6 +169,7 @@ func (yc *yamlClient) ApplyYAML(ctx context.Context, yamls ...[]byte) ([]rApi.Re
 
 		obj.SetAnnotations(ann)
 		obj.SetLabels(labels)
+
 		// If exists, update it
 		if _, err = resourceClient.Update(ctx, &obj, metav1.UpdateOptions{}); err != nil {
 			return resources, err

--- a/pkg/operator/main.go
+++ b/pkg/operator/main.go
@@ -4,76 +4,10 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/kloudlite/operator/pkg/logging"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	rawJson "github.com/kloudlite/operator/pkg/raw-json"
 )
-
-// +kubebuilder:object:generate=true
-
-type Check struct {
-	Status     bool   `json:"status"`
-	Message    string `json:"message,omitempty"`
-	Generation int64  `json:"generation,omitempty"`
-
-	// Resources     []ResourceRef `json:"resources,omitempty"`
-	// LastCheckedAt metav1.Time `json:"lastCheckedAt,omitempty"`
-}
-
-// +kubebuilder:object:generate=true
-type ResourceRef struct {
-	metav1.TypeMeta `json:",inline" graphql:"children-required"`
-	Namespace       string `json:"namespace"`
-	Name            string `json:"name"`
-}
-
-// +kubebuilder:object:generate=true
-// +kubebuilder:printcolumn:JSONPath=".status.isReady",name=Ready,type=boolean
-// +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
-
-type Status struct {
-	// +kubebuilder:validation:Optional
-	IsReady   bool             `json:"isReady"`
-	Resources []ResourceRef    `json:"resources,omitempty"`
-	Message   *rawJson.RawJson `json:"message,omitempty"`
-
-	// Messages    []ContainerMessage `json:"messages,omitempty"`
-
-	// DisplayVars *rawJson.RawJson   `json:"displayVars,omitempty"`
-
-	// GeneratedVars     *rawJson.RawJson   `json:"generatedVars,omitempty"`
-
-	// Conditions []metav1.Condition `json:"conditions,omitempty"`
-
-	// ChildConditions   []metav1.Condition `json:"childConditions,omitempty"`
-	// OpsConditions     []metav1.Condition `json:"opsConditions,omitempty"`
-
-	Checks              map[string]Check `json:"checks,omitempty"`
-	LastReadyGeneration int64            `json:"lastReadyGeneration,omitempty"`
-	LastReconcileTime   *metav1.Time     `json:"lastReconcileTime,omitempty"`
-}
-
-type Reconciler interface {
-	reconcile.Reconciler
-	SetupWithManager(mgr ctrl.Manager, logger logging.Logger) error
-	GetName() string
-}
-
-type Resource interface {
-	client.Object
-	runtime.Object
-	EnsureGVK()
-	GetStatus() *Status
-	GetEnsuredLabels() map[string]string
-	GetEnsuredAnnotations() map[string]string
-}
 
 func GetLocal[T any, V Resource](r *Request[V], key string) (T, bool) {
 	x := r.locals[key]

--- a/pkg/operator/types.go
+++ b/pkg/operator/types.go
@@ -1,0 +1,78 @@
+package operator
+
+import (
+	"github.com/kloudlite/operator/pkg/logging"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	rawJson "github.com/kloudlite/operator/pkg/raw-json"
+)
+
+// +kubebuilder:object:generate=true
+type State string
+
+const (
+	WaitingState   string = "yet-to-be-reconciled"
+	RunningState   string = "under-reconcilation"
+	ErroredState   string = "errored-during-reconcilation"
+	CompletedState string = "finished-reconcilation"
+)
+
+// +kubebuilder:object:generate=true
+type Check struct {
+	Status bool `json:"status"`
+	// State      State  `json:"state"`
+	Message    string `json:"message,omitempty"`
+	Generation int64  `json:"generation,omitempty"`
+}
+
+// +kubebuilder:object:generate=true
+type ResourceRef struct {
+	metav1.TypeMeta `json:",inline" graphql:"children-required"`
+	Namespace       string `json:"namespace"`
+	Name            string `json:"name"`
+}
+
+// +kubebuilder:object:generate=true
+// +kubebuilder:printcolumn:JSONPath=".status.isReady",name=Ready,type=boolean
+// +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
+
+type Status struct {
+	// +kubebuilder:validation:Optional
+	IsReady   bool             `json:"isReady"`
+	Resources []ResourceRef    `json:"resources,omitempty"`
+	Message   *rawJson.RawJson `json:"message,omitempty"`
+
+	// Messages    []ContainerMessage `json:"messages,omitempty"`
+
+	// DisplayVars *rawJson.RawJson   `json:"displayVars,omitempty"`
+
+	// GeneratedVars     *rawJson.RawJson   `json:"generatedVars,omitempty"`
+
+	// Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// ChildConditions   []metav1.Condition `json:"childConditions,omitempty"`
+	// OpsConditions     []metav1.Condition `json:"opsConditions,omitempty"`
+
+	Checks              map[string]Check `json:"checks,omitempty"`
+	LastReadyGeneration int64            `json:"lastReadyGeneration,omitempty"`
+	LastReconcileTime   *metav1.Time     `json:"lastReconcileTime,omitempty"`
+}
+
+type Reconciler interface {
+	reconcile.Reconciler
+	SetupWithManager(mgr ctrl.Manager, logger logging.Logger) error
+	GetName() string
+}
+
+type Resource interface {
+	client.Object
+	runtime.Object
+	EnsureGVK()
+	GetStatus() *Status
+	GetEnsuredLabels() map[string]string
+	GetEnsuredAnnotations() map[string]string
+}


### PR DESCRIPTION
## Description

**CI/CD Enhancements**
- CI has been improved to run and build images for the Wireguard and Helm Charts controllers. This ensures that these controllers are properly tested and built as part of the CI pipeline. The CHANGELOG has been updated to reflect these changes.

**RBAC Updates: Cluster Job**
- The RBAC configuration for cluster job operations has been updated. With our IAC job using a Kubernetes backend, the cluster job RBAC now allows operations on `coordination.k8s.io` resources, ensuring seamless interactions with these resources.

**CRD Updates**
- **Nodepool CRD**: S3-related configurations have been removed from `.spec.iac` to align with the shift to a Kubernetes backend and storing states in secrets.
- **Helmchart CRD**: An optional field, `.spec.releaseName`, has been added to the Helmchart CRD. This field allows modification of the Helm release name, providing greater flexibility in release naming.
- **Project CRD**: Printer column updates have been applied, improving the visibility and presentation of data related to projects.

**Operators**
- **msvc Mongo**: A finalizer has been removed from `msvc` and `mres` secrets.
- **Nodepool**: Nodepool job controller and template updates have been implemented. The controller now adds nodepool job references in resource annotations.
- **Operator Package**: Types have been extracted to a separate file, enhancing code organization.
