### PR TITLE
[KLO-116] Fix/project and cluster msvc

### DIFF
--- a/.github/workflows/delete-images-from-ghcr.yml
+++ b/.github/workflows/delete-images-from-ghcr.yml
@@ -1,0 +1,36 @@
+name: Delete Container Images from github container registry
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag_to_delete: 
+        type: string
+        description: "image tag to delete"
+        required: true
+        default: "v0.0.0"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker-builds:
+    strategy:
+      matrix:
+        app:
+          - platform
+          - agent
+          - wireguard
+          - helm-charts
+
+    name: Delete image from ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete image
+        uses: bots-house/ghcr-delete-image-action@v1.1.0
+        with:
+          owner: ${{ github.repository_owner }}
+          name:  ${{ github.event.repository.name }}/${{ matrix.app }}
+
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.event.inputs.image_tag_to_delete }}

--- a/operators/msvc-n-mres/internal/cluster-msvc/controller.go
+++ b/operators/msvc-n-mres/internal/cluster-msvc/controller.go
@@ -3,6 +3,7 @@ package cluster_msvc
 import (
 	"context"
 	"fmt"
+	"time"
 
 	crdsv1 "github.com/kloudlite/operator/apis/crds/v1"
 	"github.com/kloudlite/operator/operators/msvc-n-mres/internal/env"
@@ -195,7 +196,7 @@ func (r *Reconciler) ensureMsvcCreatedNReady(req *rApi.Request[*crdsv1.ClusterMa
 
 		return nil
 	}); err != nil {
-		return failed(err)
+		return failed(err).RequeueAfter(1 * time.Second)
 	}
 
 	req.AddToOwnedResources(rApi.ParseResourceRef(msvc))
@@ -216,8 +217,9 @@ func (r *Reconciler) ensureMsvcCreatedNReady(req *rApi.Request[*crdsv1.ClusterMa
 			return failed(err)
 		}
 		if err := r.Update(ctx, obj); err != nil {
-			return failed(err)
+			return failed(err).RequeueAfter(1 * time.Second)
 		}
+		return req.Done()
 	}
 
 	if !msvc.Status.IsReady {


### PR DESCRIPTION
Resolves kloudlite/oss#34

ci: adds github workflow to delete image tag from ghcr.io
fix(msvc-n-mres): fixes mangedservice creation, which caused infinite reconcilation of project managed service, and it would toggle from ready to not-ready