### PR TITLE
fix: hpa will now be deleted, when app `.spec.hpa.enabled = false`

### DIFF
--- a/operators/app-n-lambda/internal/templates/app-deployment-svc-hpa.yml.tpl
+++ b/operators/app-n-lambda/internal/templates/app-deployment-svc-hpa.yml.tpl
@@ -118,35 +118,5 @@ spec:
     {{- end }}
     {{- end }}
 {{- end}}
-
-{{- if $isHpaEnabled }}
----
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: {{.Name}}
-  namespace: {{.Namespace}}
-  ownerReferences: {{ $ownerRefs | toYAML | nindent 4}}
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: {{.Name}}
-  minReplicas: {{ .Spec.Hpa.MinReplicas }}
-  maxReplicas: {{ .Spec.Hpa.MaxReplicas }}
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{.Spec.Hpa.ThresholdCpu}}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{.Spec.Hpa.ThresholdMemory}}
-{{- end }}
 {{- end }}
 

--- a/operators/app-n-lambda/internal/templates/embed.go
+++ b/operators/app-n-lambda/internal/templates/embed.go
@@ -16,6 +16,7 @@ const (
 	// TODO: (user) add your template files here
 	// ClusterJobTemplate        templateFile = "./cluster-job.yml.tpl"
 	AppDeployment templateFile = "./app-deployment-svc-hpa.yml.tpl"
+	HPATemplate   templateFile = "./hpa-template.yml.tpl"
 )
 
 func Read(t templateFile) ([]byte, error) {

--- a/operators/app-n-lambda/internal/templates/hpa-template.yml.tpl
+++ b/operators/app-n-lambda/internal/templates/hpa-template.yml.tpl
@@ -1,0 +1,29 @@
+{{- /*gotype: github.com/kloudlite/operator/operators/app-n-lambda/internal/templates.HPATemplateVars*/ -}}
+{{ with . }}
+{{- if not .HPA }}
+{{ fail ".HPA must be set" }}
+{{- end }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata: {{.Metadata | toYAML | nindent 4}}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{.Metadata.Name}}
+  minReplicas: {{ .HPA.MinReplicas }}
+  maxReplicas: {{ .HPA.MaxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{.HPA.ThresholdCpu}}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{.HPA.ThresholdMemory}}
+{{ end }}

--- a/operators/app-n-lambda/internal/templates/types.go
+++ b/operators/app-n-lambda/internal/templates/types.go
@@ -1,0 +1,11 @@
+package templates
+
+import (
+	crdsv1 "github.com/kloudlite/operator/apis/crds/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type HPATemplateVars struct {
+	Metadata metav1.ObjectMeta
+	*crdsv1.HPA
+}

--- a/operators/msvc-redis/internal/controllers/standalone/service-controller.go
+++ b/operators/msvc-redis/internal/controllers/standalone/service-controller.go
@@ -56,12 +56,10 @@ const (
 )
 
 const (
-	KeyMsvcOutput   string = "msvc-output"
-	DefaultsPatched string = "defaults-patched"
+	KeyMsvcOutput string = "msvc-output"
 )
 
 var ApplyCheckList = []rApi.CheckMeta{
-	{Name: DefaultsPatched, Title: "Defaults Patched", Debug: true},
 	{Name: AccessCredsGenerated, Title: "Access Credentials Generated"},
 	{Name: RedisHelmApplied, Title: "Redis Helm Applied"},
 	{Name: RedisHelmReady, Title: "Redis Helm Ready"},


### PR DESCRIPTION
we had a bug that caused `HPA` to be available even when `.spec.hpa` has been disabled, because our template will simply skip it and apply it.

Now, we have fixed it. 