### PR TITLE
fix(helm-job-runner): corrects `curl -LO` to `curl -L0` in Dockerfile

### DIFF
--- a/operators/helm-charts/needs-images/helm-job-runner/Containerfile
+++ b/operators/helm-charts/needs-images/helm-job-runner/Containerfile
@@ -1,7 +1,0 @@
-# vim: set ft=dockerfile:
-FROM --platform=$TARGETPLATFORM docker.io/alpine/helm:3.12.3
-RUN apk add bash curl
-# FIXME: this url is for amd64 only
-ARG KUBECTL_VERSION=v1.30.0
-ARG TARGETPLATFORM
-RUN curl -LO https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${TARGETPLATFORM}/kubectl > /usr/bin/kubectl && chmod +x /usr/bin/kubectl

--- a/operators/helm-charts/needs-images/helm-job-runner/Dockerfile
+++ b/operators/helm-charts/needs-images/helm-job-runner/Dockerfile
@@ -1,0 +1,8 @@
+# vim: set ft=dockerfile:
+FROM --platform=$TARGETPLATFORM docker.io/alpine/helm:3.12.3
+WORKDIR /workspace
+RUN apk add bash curl
+# # FIXME: this url is for amd64 only
+ARG KUBECTL_VERSION=v1.30.0 TARGETPLATFORM
+RUN curl -L0 https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${TARGETPLATFORM}/kubectl > /usr/bin/kubectl
+RUN chmod +x /usr/bin/kubectl

--- a/operators/helm-charts/needs-images/helm-job-runner/Taskfile.yml
+++ b/operators/helm-charts/needs-images/helm-job-runner/Taskfile.yml
@@ -9,11 +9,4 @@ tasks:
       - sh: '[[ -n "{{.Image}}" ]]'
         msg: "var Image must have a value, of format 'image_repository:image_tag'"
     cmds:
-      - docker buildx build -f ./Containerfile --platform linux/arm64,linux/amd64 --output=type=image,compression=zstd,force-compression=true,compression-level=14,push=true   --tag {{.Image}} .
-
-  nerdctl:build-and-push:
-    preconditions:
-      - sh: '[[ -n "{{.Image}}" ]]'
-        msg: "var Image must have a value, of format 'image_repository:image_tag'"
-    cmds:
-      - nerdctl build -f ./Containerfile --platform linux/arm64,linux/amd64 --tag {{.Image}} .
+      - docker buildx build --platform linux/arm64,linux/amd64 --output=type=image,compression=zstd,force-compression=true,compression-level=14,push=true   --tag {{.Image}} .

--- a/operators/msvc-mongo/internal/controllers/standalone-service/controller.go
+++ b/operators/msvc-mongo/internal/controllers/standalone-service/controller.go
@@ -305,6 +305,8 @@ func (r *Reconciler) createStatefulSet(req *rApi.Request[*mongodbMsvcv1.Standalo
 					Labels: selectorLabels,
 				},
 				Spec: corev1.PodSpec{
+					NodeSelector: obj.Spec.NodeSelector,
+					Tolerations:  obj.Spec.Tolerations,
 					Volumes: []corev1.Volume{
 						{
 							Name: pvcName,


### PR DESCRIPTION
Resolves kloudlite/kloudlite#277

- it caused kubectl binary to be downloaded at wrong location, which caused kubectl commands to fail
- mongodb standalone controller now acknowledges nodeselector and tolerations

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the curl command in the Dockerfile to address kubectl download issues and update the MongoDB standalone controller to support nodeSelector and tolerations. Remove the unused Containerfile from the helm-job-runner directory.

Bug Fixes:
- Correct the curl command in the Dockerfile to ensure the kubectl binary is downloaded to the correct location, preventing command failures.

Enhancements:
- Update the MongoDB standalone controller to acknowledge nodeSelector and tolerations in the pod specification.

Chores:
- Remove the Containerfile from the helm-job-runner directory.

<!-- Generated by sourcery-ai[bot]: end summary -->