### PR TITLE
feat(suspend-env): allows (un)suspending an environment

### DIFF
--- a/apis/crds/v1/environment_types.go
+++ b/apis/crds/v1/environment_types.go
@@ -26,6 +26,8 @@ type EnvironmentSpec struct {
 	TargetNamespace string `json:"targetNamespace,omitempty"`
 
 	Routing *EnvironmentRouting `json:"routing,omitempty"`
+
+	Suspend bool `json:"suspend,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/apis/crds/v1/environment_types.go
+++ b/apis/crds/v1/environment_types.go
@@ -36,7 +36,7 @@ type EnvironmentSpec struct {
 //+kubebuilder:printcolumn:JSONPath=".spec.targetNamespace",name="target-ns",type=string
 //+kubebuilder:printcolumn:JSONPath=".status.lastReconcileTime",name=Seen,type=date
 //+kubebuilder:printcolumn:JSONPath=".metadata.annotations.kloudlite\\.io\\/checks",name=Checks,type=string
-//+kubebuilder:printcolumn:JSONPath=".metadata.annotations.kloudlite\\.io\\/environment\\.routing",name=Routing,type=string
+//+kubebuilder:printcolumn:JSONPath=".spec.suspend",name=Suspend,type=boolean
 //+kubebuilder:printcolumn:JSONPath=".metadata.annotations.kloudlite\\.io\\/resource\\.ready",name=Ready,type=string
 //+kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
 

--- a/config/crd/bases/crds.kloudlite.io_environments.yaml
+++ b/config/crd/bases/crds.kloudlite.io_environments.yaml
@@ -25,9 +25,9 @@ spec:
     - jsonPath: .metadata.annotations.kloudlite\.io\/checks
       name: Checks
       type: string
-    - jsonPath: .metadata.annotations.kloudlite\.io\/environment\.routing
-      name: Routing
-      type: string
+    - jsonPath: .spec.suspend
+      name: Suspend
+      type: boolean
     - jsonPath: .metadata.annotations.kloudlite\.io\/resource\.ready
       name: Ready
       type: string

--- a/config/crd/bases/crds.kloudlite.io_environments.yaml
+++ b/config/crd/bases/crds.kloudlite.io_environments.yaml
@@ -63,6 +63,8 @@ spec:
                   publicIngressClass:
                     type: string
                 type: object
+              suspend:
+                type: boolean
               targetNamespace:
                 type: string
             type: object

--- a/config/crd/bases/crds.kloudlite.io_helmcharts.yaml
+++ b/config/crd/bases/crds.kloudlite.io_helmcharts.yaml
@@ -312,7 +312,8 @@ spec:
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
-                                        in this case pods.
+                                        in this case pods. If it's null, this PodAffinityTerm
+                                        matches with no Pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -363,6 +364,48 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key in (value)` to select the group of
+                                        existing pods which pods will be taken into
+                                        consideration for the incoming pod's pod (anti)
+                                        affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value
+                                        is empty. The same key is forbidden to exist
+                                        in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector
+                                        isn't set. This is an alpha field and requires
+                                        enabling MatchLabelKeysInPodAffinity feature
+                                        gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key notin (value)` to select the group
+                                        of existing pods which pods will be taken
+                                        into consideration for the incoming pod's
+                                        pod (anti) affinity. Keys that don't exist
+                                        in the incoming pod labels will be ignored.
+                                        The default value is empty. The same key is
+                                        forbidden to exist in both MismatchLabelKeys
+                                        and LabelSelector. Also, MismatchLabelKeys
+                                        cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling
+                                        MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -476,7 +519,8 @@ spec:
                               properties:
                                 labelSelector:
                                   description: A label query over a set of resources,
-                                    in this case pods.
+                                    in this case pods. If it's null, this PodAffinityTerm
+                                    matches with no Pods.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -526,6 +570,44 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key in (value)` to select
+                                    the group of existing pods which pods will be
+                                    taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MatchLabelKeys and LabelSelector. Also,
+                                    MatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: MismatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key notin (value)` to
+                                    select the group of existing pods which pods will
+                                    be taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MismatchLabelKeys and LabelSelector. Also,
+                                    MismatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -636,7 +718,8 @@ spec:
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
-                                        in this case pods.
+                                        in this case pods. If it's null, this PodAffinityTerm
+                                        matches with no Pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -687,6 +770,48 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key in (value)` to select the group of
+                                        existing pods which pods will be taken into
+                                        consideration for the incoming pod's pod (anti)
+                                        affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value
+                                        is empty. The same key is forbidden to exist
+                                        in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector
+                                        isn't set. This is an alpha field and requires
+                                        enabling MatchLabelKeysInPodAffinity feature
+                                        gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key notin (value)` to select the group
+                                        of existing pods which pods will be taken
+                                        into consideration for the incoming pod's
+                                        pod (anti) affinity. Keys that don't exist
+                                        in the incoming pod labels will be ignored.
+                                        The default value is empty. The same key is
+                                        forbidden to exist in both MismatchLabelKeys
+                                        and LabelSelector. Also, MismatchLabelKeys
+                                        cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling
+                                        MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -800,7 +925,8 @@ spec:
                               properties:
                                 labelSelector:
                                   description: A label query over a set of resources,
-                                    in this case pods.
+                                    in this case pods. If it's null, this PodAffinityTerm
+                                    matches with no Pods.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -850,6 +976,44 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key in (value)` to select
+                                    the group of existing pods which pods will be
+                                    taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MatchLabelKeys and LabelSelector. Also,
+                                    MatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: MismatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key notin (value)` to
+                                    select the group of existing pods which pods will
+                                    be taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MismatchLabelKeys and LabelSelector. Also,
+                                    MismatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied

--- a/config/crd/bases/crds.kloudlite.io_lifecycles.yaml
+++ b/config/crd/bases/crds.kloudlite.io_lifecycles.yaml
@@ -317,7 +317,9 @@ spec:
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of
-                                            resources, in this case pods.
+                                            resources, in this case pods. If it's
+                                            null, this PodAffinityTerm matches with
+                                            no Pods.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -371,6 +373,51 @@ spec:
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: MatchLabelKeys is a set of
+                                            pod label keys to select which pods will
+                                            be taken into consideration. The keys
+                                            are used to lookup values from the incoming
+                                            pod labels, those key-value labels are
+                                            merged with `LabelSelector` as `key in
+                                            (value)` to select the group of existing
+                                            pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity.
+                                            Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default
+                                            value is empty. The same key is forbidden
+                                            to exist in both MatchLabelKeys and LabelSelector.
+                                            Also, MatchLabelKeys cannot be set when
+                                            LabelSelector isn't set. This is an alpha
+                                            field and requires enabling MatchLabelKeysInPodAffinity
+                                            feature gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: MismatchLabelKeys is a set
+                                            of pod label keys to select which pods
+                                            will be taken into consideration. The
+                                            keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels
+                                            are merged with `LabelSelector` as `key
+                                            notin (value)` to select the group of
+                                            existing pods which pods will be taken
+                                            into consideration for the incoming pod's
+                                            pod (anti) affinity. Keys that don't exist
+                                            in the incoming pod labels will be ignored.
+                                            The default value is empty. The same key
+                                            is forbidden to exist in both MismatchLabelKeys
+                                            and LabelSelector. Also, MismatchLabelKeys
+                                            cannot be set when LabelSelector isn't
+                                            set. This is an alpha field and requires
+                                            enabling MatchLabelKeysInPodAffinity feature
+                                            gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         namespaceSelector:
                                           description: A label query over the set
                                             of namespaces that the term applies to.
@@ -492,7 +539,8 @@ spec:
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
-                                        in this case pods.
+                                        in this case pods. If it's null, this PodAffinityTerm
+                                        matches with no Pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -543,6 +591,48 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key in (value)` to select the group of
+                                        existing pods which pods will be taken into
+                                        consideration for the incoming pod's pod (anti)
+                                        affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value
+                                        is empty. The same key is forbidden to exist
+                                        in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector
+                                        isn't set. This is an alpha field and requires
+                                        enabling MatchLabelKeysInPodAffinity feature
+                                        gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key notin (value)` to select the group
+                                        of existing pods which pods will be taken
+                                        into consideration for the incoming pod's
+                                        pod (anti) affinity. Keys that don't exist
+                                        in the incoming pod labels will be ignored.
+                                        The default value is empty. The same key is
+                                        forbidden to exist in both MismatchLabelKeys
+                                        and LabelSelector. Also, MismatchLabelKeys
+                                        cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling
+                                        MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -657,7 +747,9 @@ spec:
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of
-                                            resources, in this case pods.
+                                            resources, in this case pods. If it's
+                                            null, this PodAffinityTerm matches with
+                                            no Pods.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -711,6 +803,51 @@ spec:
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: MatchLabelKeys is a set of
+                                            pod label keys to select which pods will
+                                            be taken into consideration. The keys
+                                            are used to lookup values from the incoming
+                                            pod labels, those key-value labels are
+                                            merged with `LabelSelector` as `key in
+                                            (value)` to select the group of existing
+                                            pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity.
+                                            Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default
+                                            value is empty. The same key is forbidden
+                                            to exist in both MatchLabelKeys and LabelSelector.
+                                            Also, MatchLabelKeys cannot be set when
+                                            LabelSelector isn't set. This is an alpha
+                                            field and requires enabling MatchLabelKeysInPodAffinity
+                                            feature gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: MismatchLabelKeys is a set
+                                            of pod label keys to select which pods
+                                            will be taken into consideration. The
+                                            keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels
+                                            are merged with `LabelSelector` as `key
+                                            notin (value)` to select the group of
+                                            existing pods which pods will be taken
+                                            into consideration for the incoming pod's
+                                            pod (anti) affinity. Keys that don't exist
+                                            in the incoming pod labels will be ignored.
+                                            The default value is empty. The same key
+                                            is forbidden to exist in both MismatchLabelKeys
+                                            and LabelSelector. Also, MismatchLabelKeys
+                                            cannot be set when LabelSelector isn't
+                                            set. This is an alpha field and requires
+                                            enabling MatchLabelKeysInPodAffinity feature
+                                            gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         namespaceSelector:
                                           description: A label query over the set
                                             of namespaces that the term applies to.
@@ -832,7 +969,8 @@ spec:
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
-                                        in this case pods.
+                                        in this case pods. If it's null, this PodAffinityTerm
+                                        matches with no Pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -883,6 +1021,48 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key in (value)` to select the group of
+                                        existing pods which pods will be taken into
+                                        consideration for the incoming pod's pod (anti)
+                                        affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value
+                                        is empty. The same key is forbidden to exist
+                                        in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector
+                                        isn't set. This is an alpha field and requires
+                                        enabling MatchLabelKeysInPodAffinity feature
+                                        gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key notin (value)` to select the group
+                                        of existing pods which pods will be taken
+                                        into consideration for the incoming pod's
+                                        pod (anti) affinity. Keys that don't exist
+                                        in the incoming pod labels will be ignored.
+                                        The default value is empty. The same key is
+                                        forbidden to exist in both MismatchLabelKeys
+                                        and LabelSelector. Also, MismatchLabelKeys
+                                        cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling
+                                        MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -1275,6 +1455,18 @@ spec:
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
                                       description: Deprecated. TCPSocket is NOT supported
                                         as a LifecycleHandler and kept for the backward
@@ -1381,6 +1573,18 @@ spec:
                                           type: string
                                       required:
                                       - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
                                       type: object
                                     tcpSocket:
                                       description: Deprecated. TCPSocket is NOT supported
@@ -2710,6 +2914,18 @@ spec:
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
                                       description: Deprecated. TCPSocket is NOT supported
                                         as a LifecycleHandler and kept for the backward
@@ -2816,6 +3032,18 @@ spec:
                                           type: string
                                       required:
                                       - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
                                       type: object
                                     tcpSocket:
                                       description: Deprecated. TCPSocket is NOT supported
@@ -4142,6 +4370,18 @@ spec:
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
                                       description: Deprecated. TCPSocket is NOT supported
                                         as a LifecycleHandler and kept for the backward
@@ -4248,6 +4488,18 @@ spec:
                                           type: string
                                       required:
                                       - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
                                       type: object
                                     tcpSocket:
                                       description: Deprecated. TCPSocket is NOT supported
@@ -6483,32 +6735,6 @@ spec:
                                             status field of the claim. More info:
                                             https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                           properties:
-                                            claims:
-                                              description: "Claims lists the names
-                                                of resources, defined in spec.resourceClaims,
-                                                that are used by this container. \n
-                                                This is an alpha field and requires
-                                                enabling the DynamicResourceAllocation
-                                                feature gate. \n This field is immutable.
-                                                It can only be set for containers."
-                                              items:
-                                                description: ResourceClaim references
-                                                  one entry in PodSpec.ResourceClaims.
-                                                properties:
-                                                  name:
-                                                    description: Name must match the
-                                                      name of one entry in pod.spec.resourceClaims
-                                                      of the Pod where this field
-                                                      is used. It makes that resource
-                                                      available inside a container.
-                                                    type: string
-                                                required:
-                                                - name
-                                                type: object
-                                              type: array
-                                              x-kubernetes-list-map-keys:
-                                              - name
-                                              x-kubernetes-list-type: map
                                             limits:
                                               additionalProperties:
                                                 anyOf:
@@ -6597,6 +6823,32 @@ spec:
                                           description: 'storageClassName is the name
                                             of the StorageClass required by the claim.
                                             More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          type: string
+                                        volumeAttributesClassName:
+                                          description: 'volumeAttributesClassName
+                                            may be used to set the VolumeAttributesClass
+                                            used by this claim. If specified, the
+                                            CSI driver will create or update the volume
+                                            with the attributes defined in the corresponding
+                                            VolumeAttributesClass. This has a different
+                                            purpose than storageClassName, it can
+                                            be changed after the claim is created.
+                                            An empty string value means that no VolumeAttributesClass
+                                            will be applied to the claim but it''s
+                                            not allowed to reset this field to empty
+                                            string once it is set. If unspecified
+                                            and the PersistentVolumeClaim is unbound,
+                                            the default VolumeAttributesClass will
+                                            be set by the persistentvolume controller
+                                            if it exists. If the resource referred
+                                            to by volumeAttributesClass does not exist,
+                                            this PersistentVolumeClaim will be set
+                                            to a Pending state, as reflected by the
+                                            modifyVolumeStatus field, until such as
+                                            a resource exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                            (Alpha) Using this field requires the
+                                            VolumeAttributesClass feature gate to
+                                            be enabled.'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type
@@ -6999,6 +7251,114 @@ spec:
                                     description: Projection that may be projected
                                       along with other supported volume types
                                     properties:
+                                      clusterTrustBundle:
+                                        description: "ClusterTrustBundle allows a
+                                          pod to access the `.spec.trustBundle` field
+                                          of ClusterTrustBundle objects in an auto-updating
+                                          file. \n Alpha, gated by the ClusterTrustBundleProjection
+                                          feature gate. \n ClusterTrustBundle objects
+                                          can either be selected by name, or by the
+                                          combination of signer name and a label selector.
+                                          \n Kubelet performs aggressive normalization
+                                          of the PEM contents written into the pod
+                                          filesystem.  Esoteric PEM features such
+                                          as inter-block comments and block headers
+                                          are stripped.  Certificates are deduplicated.
+                                          The ordering of certificates within the
+                                          file is arbitrary, and Kubelet may change
+                                          the order over time."
+                                        properties:
+                                          labelSelector:
+                                            description: Select all ClusterTrustBundles
+                                              that match this label selector.  Only
+                                              has effect if signerName is set.  Mutually-exclusive
+                                              with name.  If unset, interpreted as
+                                              "match nothing".  If set but empty,
+                                              interpreted as "match everything".
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            description: Select a single ClusterTrustBundle
+                                              by object name.  Mutually-exclusive
+                                              with signerName and labelSelector.
+                                            type: string
+                                          optional:
+                                            description: If true, don't block pod
+                                              startup if the referenced ClusterTrustBundle(s)
+                                              aren't available.  If using name, then
+                                              the named ClusterTrustBundle is allowed
+                                              not to exist.  If using signerName,
+                                              then the combination of signerName and
+                                              labelSelector is allowed to match zero
+                                              ClusterTrustBundles.
+                                            type: boolean
+                                          path:
+                                            description: Relative path from the volume
+                                              root to write the bundle.
+                                            type: string
+                                          signerName:
+                                            description: Select all ClusterTrustBundles
+                                              that match this signer name. Mutually-exclusive
+                                              with name.  The contents of all selected
+                                              ClusterTrustBundles will be unified
+                                              and deduplicated.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
                                       configMap:
                                         description: configMap information about the
                                           configMap data to project
@@ -7843,7 +8203,9 @@ spec:
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of
-                                            resources, in this case pods.
+                                            resources, in this case pods. If it's
+                                            null, this PodAffinityTerm matches with
+                                            no Pods.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -7897,6 +8259,51 @@ spec:
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: MatchLabelKeys is a set of
+                                            pod label keys to select which pods will
+                                            be taken into consideration. The keys
+                                            are used to lookup values from the incoming
+                                            pod labels, those key-value labels are
+                                            merged with `LabelSelector` as `key in
+                                            (value)` to select the group of existing
+                                            pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity.
+                                            Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default
+                                            value is empty. The same key is forbidden
+                                            to exist in both MatchLabelKeys and LabelSelector.
+                                            Also, MatchLabelKeys cannot be set when
+                                            LabelSelector isn't set. This is an alpha
+                                            field and requires enabling MatchLabelKeysInPodAffinity
+                                            feature gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: MismatchLabelKeys is a set
+                                            of pod label keys to select which pods
+                                            will be taken into consideration. The
+                                            keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels
+                                            are merged with `LabelSelector` as `key
+                                            notin (value)` to select the group of
+                                            existing pods which pods will be taken
+                                            into consideration for the incoming pod's
+                                            pod (anti) affinity. Keys that don't exist
+                                            in the incoming pod labels will be ignored.
+                                            The default value is empty. The same key
+                                            is forbidden to exist in both MismatchLabelKeys
+                                            and LabelSelector. Also, MismatchLabelKeys
+                                            cannot be set when LabelSelector isn't
+                                            set. This is an alpha field and requires
+                                            enabling MatchLabelKeysInPodAffinity feature
+                                            gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         namespaceSelector:
                                           description: A label query over the set
                                             of namespaces that the term applies to.
@@ -8018,7 +8425,8 @@ spec:
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
-                                        in this case pods.
+                                        in this case pods. If it's null, this PodAffinityTerm
+                                        matches with no Pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -8069,6 +8477,48 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key in (value)` to select the group of
+                                        existing pods which pods will be taken into
+                                        consideration for the incoming pod's pod (anti)
+                                        affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value
+                                        is empty. The same key is forbidden to exist
+                                        in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector
+                                        isn't set. This is an alpha field and requires
+                                        enabling MatchLabelKeysInPodAffinity feature
+                                        gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key notin (value)` to select the group
+                                        of existing pods which pods will be taken
+                                        into consideration for the incoming pod's
+                                        pod (anti) affinity. Keys that don't exist
+                                        in the incoming pod labels will be ignored.
+                                        The default value is empty. The same key is
+                                        forbidden to exist in both MismatchLabelKeys
+                                        and LabelSelector. Also, MismatchLabelKeys
+                                        cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling
+                                        MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -8183,7 +8633,9 @@ spec:
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of
-                                            resources, in this case pods.
+                                            resources, in this case pods. If it's
+                                            null, this PodAffinityTerm matches with
+                                            no Pods.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -8237,6 +8689,51 @@ spec:
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: MatchLabelKeys is a set of
+                                            pod label keys to select which pods will
+                                            be taken into consideration. The keys
+                                            are used to lookup values from the incoming
+                                            pod labels, those key-value labels are
+                                            merged with `LabelSelector` as `key in
+                                            (value)` to select the group of existing
+                                            pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity.
+                                            Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default
+                                            value is empty. The same key is forbidden
+                                            to exist in both MatchLabelKeys and LabelSelector.
+                                            Also, MatchLabelKeys cannot be set when
+                                            LabelSelector isn't set. This is an alpha
+                                            field and requires enabling MatchLabelKeysInPodAffinity
+                                            feature gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: MismatchLabelKeys is a set
+                                            of pod label keys to select which pods
+                                            will be taken into consideration. The
+                                            keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels
+                                            are merged with `LabelSelector` as `key
+                                            notin (value)` to select the group of
+                                            existing pods which pods will be taken
+                                            into consideration for the incoming pod's
+                                            pod (anti) affinity. Keys that don't exist
+                                            in the incoming pod labels will be ignored.
+                                            The default value is empty. The same key
+                                            is forbidden to exist in both MismatchLabelKeys
+                                            and LabelSelector. Also, MismatchLabelKeys
+                                            cannot be set when LabelSelector isn't
+                                            set. This is an alpha field and requires
+                                            enabling MatchLabelKeysInPodAffinity feature
+                                            gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         namespaceSelector:
                                           description: A label query over the set
                                             of namespaces that the term applies to.
@@ -8358,7 +8855,8 @@ spec:
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
-                                        in this case pods.
+                                        in this case pods. If it's null, this PodAffinityTerm
+                                        matches with no Pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -8409,6 +8907,48 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key in (value)` to select the group of
+                                        existing pods which pods will be taken into
+                                        consideration for the incoming pod's pod (anti)
+                                        affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value
+                                        is empty. The same key is forbidden to exist
+                                        in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector
+                                        isn't set. This is an alpha field and requires
+                                        enabling MatchLabelKeysInPodAffinity feature
+                                        gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key notin (value)` to select the group
+                                        of existing pods which pods will be taken
+                                        into consideration for the incoming pod's
+                                        pod (anti) affinity. Keys that don't exist
+                                        in the incoming pod labels will be ignored.
+                                        The default value is empty. The same key is
+                                        forbidden to exist in both MismatchLabelKeys
+                                        and LabelSelector. Also, MismatchLabelKeys
+                                        cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling
+                                        MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -8801,6 +9341,18 @@ spec:
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
                                       description: Deprecated. TCPSocket is NOT supported
                                         as a LifecycleHandler and kept for the backward
@@ -8907,6 +9459,18 @@ spec:
                                           type: string
                                       required:
                                       - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
                                       type: object
                                     tcpSocket:
                                       description: Deprecated. TCPSocket is NOT supported
@@ -10236,6 +10800,18 @@ spec:
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
                                       description: Deprecated. TCPSocket is NOT supported
                                         as a LifecycleHandler and kept for the backward
@@ -10342,6 +10918,18 @@ spec:
                                           type: string
                                       required:
                                       - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
                                       type: object
                                     tcpSocket:
                                       description: Deprecated. TCPSocket is NOT supported
@@ -11668,6 +12256,18 @@ spec:
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
                                       description: Deprecated. TCPSocket is NOT supported
                                         as a LifecycleHandler and kept for the backward
@@ -11774,6 +12374,18 @@ spec:
                                           type: string
                                       required:
                                       - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
                                       type: object
                                     tcpSocket:
                                       description: Deprecated. TCPSocket is NOT supported
@@ -14009,32 +14621,6 @@ spec:
                                             status field of the claim. More info:
                                             https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                           properties:
-                                            claims:
-                                              description: "Claims lists the names
-                                                of resources, defined in spec.resourceClaims,
-                                                that are used by this container. \n
-                                                This is an alpha field and requires
-                                                enabling the DynamicResourceAllocation
-                                                feature gate. \n This field is immutable.
-                                                It can only be set for containers."
-                                              items:
-                                                description: ResourceClaim references
-                                                  one entry in PodSpec.ResourceClaims.
-                                                properties:
-                                                  name:
-                                                    description: Name must match the
-                                                      name of one entry in pod.spec.resourceClaims
-                                                      of the Pod where this field
-                                                      is used. It makes that resource
-                                                      available inside a container.
-                                                    type: string
-                                                required:
-                                                - name
-                                                type: object
-                                              type: array
-                                              x-kubernetes-list-map-keys:
-                                              - name
-                                              x-kubernetes-list-type: map
                                             limits:
                                               additionalProperties:
                                                 anyOf:
@@ -14123,6 +14709,32 @@ spec:
                                           description: 'storageClassName is the name
                                             of the StorageClass required by the claim.
                                             More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          type: string
+                                        volumeAttributesClassName:
+                                          description: 'volumeAttributesClassName
+                                            may be used to set the VolumeAttributesClass
+                                            used by this claim. If specified, the
+                                            CSI driver will create or update the volume
+                                            with the attributes defined in the corresponding
+                                            VolumeAttributesClass. This has a different
+                                            purpose than storageClassName, it can
+                                            be changed after the claim is created.
+                                            An empty string value means that no VolumeAttributesClass
+                                            will be applied to the claim but it''s
+                                            not allowed to reset this field to empty
+                                            string once it is set. If unspecified
+                                            and the PersistentVolumeClaim is unbound,
+                                            the default VolumeAttributesClass will
+                                            be set by the persistentvolume controller
+                                            if it exists. If the resource referred
+                                            to by volumeAttributesClass does not exist,
+                                            this PersistentVolumeClaim will be set
+                                            to a Pending state, as reflected by the
+                                            modifyVolumeStatus field, until such as
+                                            a resource exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                            (Alpha) Using this field requires the
+                                            VolumeAttributesClass feature gate to
+                                            be enabled.'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type
@@ -14525,6 +15137,114 @@ spec:
                                     description: Projection that may be projected
                                       along with other supported volume types
                                     properties:
+                                      clusterTrustBundle:
+                                        description: "ClusterTrustBundle allows a
+                                          pod to access the `.spec.trustBundle` field
+                                          of ClusterTrustBundle objects in an auto-updating
+                                          file. \n Alpha, gated by the ClusterTrustBundleProjection
+                                          feature gate. \n ClusterTrustBundle objects
+                                          can either be selected by name, or by the
+                                          combination of signer name and a label selector.
+                                          \n Kubelet performs aggressive normalization
+                                          of the PEM contents written into the pod
+                                          filesystem.  Esoteric PEM features such
+                                          as inter-block comments and block headers
+                                          are stripped.  Certificates are deduplicated.
+                                          The ordering of certificates within the
+                                          file is arbitrary, and Kubelet may change
+                                          the order over time."
+                                        properties:
+                                          labelSelector:
+                                            description: Select all ClusterTrustBundles
+                                              that match this label selector.  Only
+                                              has effect if signerName is set.  Mutually-exclusive
+                                              with name.  If unset, interpreted as
+                                              "match nothing".  If set but empty,
+                                              interpreted as "match everything".
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            description: Select a single ClusterTrustBundle
+                                              by object name.  Mutually-exclusive
+                                              with signerName and labelSelector.
+                                            type: string
+                                          optional:
+                                            description: If true, don't block pod
+                                              startup if the referenced ClusterTrustBundle(s)
+                                              aren't available.  If using name, then
+                                              the named ClusterTrustBundle is allowed
+                                              not to exist.  If using signerName,
+                                              then the combination of signerName and
+                                              labelSelector is allowed to match zero
+                                              ClusterTrustBundles.
+                                            type: boolean
+                                          path:
+                                            description: Relative path from the volume
+                                              root to write the bundle.
+                                            type: string
+                                          signerName:
+                                            description: Select all ClusterTrustBundles
+                                              that match this signer name. Mutually-exclusive
+                                              with name.  The contents of all selected
+                                              ClusterTrustBundles will be unified
+                                              and deduplicated.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
                                       configMap:
                                         description: configMap information about the
                                           configMap data to project

--- a/config/crd/bases/networking.kloudlite.io_servicebindings.yaml
+++ b/config/crd/bases/networking.kloudlite.io_servicebindings.yaml
@@ -64,7 +64,7 @@ spec:
                         protocol names - reserved for IANA standard service names
                         (as per RFC-6335 and https://www.iana.org/assignments/service-names).
                         \n * Kubernetes-defined prefixed names: * 'kubernetes.io/h2c'
-                        - HTTP/2 over cleartext as described in https://www.rfc-editor.org/rfc/rfc7540
+                        - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
                         * 'kubernetes.io/ws'  - WebSocket over cleartext as described
                         in https://www.rfc-editor.org/rfc/rfc6455 * 'kubernetes.io/wss'
                         - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455

--- a/operators/msvc-mongo/internal/controllers/standalone-service/controller.go
+++ b/operators/msvc-mongo/internal/controllers/standalone-service/controller.go
@@ -294,7 +294,7 @@ func (r *Reconciler) createStatefulSet(req *rApi.Request[*mongodbMsvcv1.Standalo
 
 		sts.Spec.Replicas = fn.New(int32(1))
 
-		sts.Spec = appsv1.StatefulSetSpec{
+		spec := appsv1.StatefulSetSpec{
 			Replicas: fn.New(int32(1)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,
@@ -357,9 +357,19 @@ func (r *Reconciler) createStatefulSet(req *rApi.Request[*mongodbMsvcv1.Standalo
 				},
 			},
 		}
+
+		if obj.GetGeneration() > 0 {
+			// resource exists, and is being updated now
+			// INFO: k8s statefulsets forbids update to spec fields, other than "replicas", "template", "ordinals", "updateStrategy", "persistentVolumeClaimRetentionPolicy" and "minReadySeconds",
+
+			sts.Spec.Replicas = spec.Replicas
+			sts.Spec.Template = spec.Template
+		} else {
+			sts.Spec = spec
+		}
+
 		return nil
 	}); err != nil {
-		r.logger.Infof("Failed to create statefulset: err=%v, resource:\n%+v\n", err, sts)
 		return check.Failed(err)
 	}
 

--- a/operators/msvc-mysql/internal/controllers/standalone-service/controller.go
+++ b/operators/msvc-mysql/internal/controllers/standalone-service/controller.go
@@ -293,7 +293,7 @@ func (r *ServiceReconciler) createStatefulSet(req *rApi.Request[*mysqlMsvcv1.Sta
 			fn.MapSet(&sts.Labels, k, v)
 		}
 
-		sts.Spec = appsv1.StatefulSetSpec{
+		spec := appsv1.StatefulSetSpec{
 			Replicas: fn.New(int32(1)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,
@@ -344,6 +344,17 @@ func (r *ServiceReconciler) createStatefulSet(req *rApi.Request[*mysqlMsvcv1.Sta
 				},
 			},
 		}
+
+		if obj.GetGeneration() > 0 {
+			// resource exists, and is being updated now
+			// INFO: k8s statefulsets forbids update to spec fields, other than "replicas", "template", "ordinals", "updateStrategy",  "persistentVolumeClaimRetentionPolicy" and "minReadySeconds",
+
+			sts.Spec.Replicas = spec.Replicas
+			sts.Spec.Template = spec.Template
+		} else {
+			sts.Spec = spec
+		}
+
 		return nil
 	}); err != nil {
 		return check.Failed(err)

--- a/operators/msvc-postgres/internal/controllers/standalone-service/controller.go
+++ b/operators/msvc-postgres/internal/controllers/standalone-service/controller.go
@@ -286,7 +286,7 @@ func (r *Reconciler) createStatefulSet(req *rApi.Request[*postgresv1.Standalone]
 			fn.MapSet(&sts.Labels, k, v)
 		}
 
-		sts.Spec = appsv1.StatefulSetSpec{
+		spec := appsv1.StatefulSetSpec{
 			Replicas: fn.New(int32(1)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,
@@ -360,6 +360,17 @@ func (r *Reconciler) createStatefulSet(req *rApi.Request[*postgresv1.Standalone]
 				},
 			},
 		}
+
+		if obj.GetGeneration() > 0 {
+			// resource exists, and is being updated now
+			// INFO: k8s statefulsets forbids update to spec fields, other than "replicas", "template", "ordinals", "updateStrategy",  "persistentVolumeClaimRetentionPolicy" and "minReadySeconds",
+
+			sts.Spec.Replicas = spec.Replicas
+			sts.Spec.Template = spec.Template
+		} else {
+			sts.Spec = spec
+		}
+
 		return nil
 	}); err != nil {
 		return check.Failed(err)

--- a/operators/networking/internal/cmd/ip-binding-controller/main.go
+++ b/operators/networking/internal/cmd/ip-binding-controller/main.go
@@ -13,7 +13,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	mgr := operator.New("service-binding")
+	mgr := operator.New("ip-binding")
 	mgr.AddToSchemes(networkingv1.AddToScheme)
 	mgr.RegisterControllers(
 		&service_binding.Reconciler{Env: ev, Name: "svc-binding"},

--- a/operators/networking/internal/cmd/ip-binding-controller/pod-pinger/controller.go
+++ b/operators/networking/internal/cmd/ip-binding-controller/pod-pinger/controller.go
@@ -3,6 +3,9 @@ package pod_pinger
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"os"
+	"strings"
 	"time"
 
 	networkingv1 "github.com/kloudlite/operator/apis/networking/v1"
@@ -12,6 +15,7 @@ import (
 	"github.com/kloudlite/operator/pkg/kubectl"
 	"github.com/kloudlite/operator/pkg/logging"
 	rApi "github.com/kloudlite/operator/pkg/operator"
+	probing "github.com/prometheus-community/pro-bing"
 	corev1 "k8s.io/api/core/v1"
 	apiLabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,15 +24,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	probing "github.com/prometheus-community/pro-bing"
 )
 
 type Reconciler struct {
 	client.Client
 	Scheme     *runtime.Scheme
 	Env        *env.Env
-	logger     logging.Logger
+	logger     *slog.Logger
 	Name       string
 	yamlClient kubectl.YAMLClient
 }
@@ -49,9 +51,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	r.logger.Debug("[start] reconciling", "pod", fmt.Sprintf("%s/%s", pod.GetNamespace(), pod.GetName()))
+
 	v, ok := pod.GetLabels()[constants.KloudliteGatewayEnabledLabel]
 	if !ok {
-		r.logger.Infof("pod %s/%s is not registered with gateway, deleting it", pod.GetNamespace(), pod.GetName())
+		r.logger.Info("pod not registered with gateway, deleting it", "pod", fmt.Sprintf("%s/%s", pod.GetNamespace(), pod.GetName()))
 		if err := r.Delete(ctx, pod); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -78,9 +82,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
+	// if out, err := exec.CommandContext(ctx, "timeout", "1", "ping", "-c", "1", pblist.Items[0].Spec.GlobalIP).CombinedOutput(); err != nil {
+	// 	r.logger.Errorf(err, "failed to ping %s (%s/%s)", pblist.Items[0].Spec.GlobalIP, pod.GetNamespace(), pod.GetName())
+	// 	r.logger.Infof("output of ping: %s", out)
+	// 	if _, ok := pod.Labels[KloudlitePodActiveLabel]; !ok {
+	// 		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+	// 	}
+	// 	if err := r.Delete(ctx, pod); err != nil {
+	// 		return ctrl.Result{}, err
+	// 	}
+	// 	return ctrl.Result{}, err
+	// }
+
 	pinger, err := probing.NewPinger(pblist.Items[0].Spec.GlobalIP)
 	if err != nil {
-		r.logger.Errorf(err, "failed to create pinger for %s", v)
+		r.logger.Error("failed to create pinger, got", "err", err, "pod", fmt.Sprintf("%s/%s", pod.GetNamespace(), pod.GetName()))
 		return ctrl.Result{}, err
 	}
 
@@ -88,7 +104,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	pinger.Timeout = 500 * time.Millisecond
 
 	if err = pinger.RunWithContext(ctx); err != nil {
-		r.logger.Errorf(err, "failed to ping %s", v)
+		r.logger.Error("failed to ping, got", "err", err, "pod", fmt.Sprintf("%s/%s", pod.GetNamespace(), pod.GetName()))
 		if _, ok := pod.Labels[KloudlitePodActiveLabel]; !ok {
 			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 		}
@@ -101,20 +117,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	if _, ok := pod.Labels[KloudlitePodActiveLabel]; !ok {
 		fn.MapSet(&pod.Labels, KloudlitePodActiveLabel, "true")
 		if err := r.Update(ctx, pod); err != nil {
-			r.logger.Errorf(err, "failed to update pod %s/%s", pod.GetNamespace(), pod.GetName())
+			r.logger.Error("failed to update pod, got", "err", err, "pod", fmt.Sprintf("%s/%s", pod.GetNamespace(), pod.GetName()))
 			return ctrl.Result{}, err
 		}
 	}
 
-	r.logger.Debugf("ping success for %s, requeing after 5s", v)
+	r.logger.Debug("ping success, requeing after 5s", "pod", fmt.Sprintf("%s/%s", pod.GetNamespace(), pod.GetName()))
 	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, logger logging.Logger) error {
 	r.Client = mgr.GetClient()
 	r.Scheme = mgr.GetScheme()
-	r.logger = logger.WithName(r.Name)
-	r.yamlClient = kubectl.NewYAMLClientOrDie(mgr.GetConfig(), kubectl.YAMLClientOpts{Logger: r.logger})
+	r.logger = logging.NewSlogLogger(logging.SlogOptions{
+		Prefix:        r.Name,
+		ShowCaller:    true,
+		ShowDebugLogs: strings.ToLower(os.Getenv("DEBUG_LOG")) == "true",
+	})
+	r.yamlClient = kubectl.NewYAMLClientOrDie(mgr.GetConfig(), kubectl.YAMLClientOpts{Logger: logger.WithName(r.Name)})
 
 	builder := ctrl.NewControllerManagedBy(mgr).For(&networkingv1.PodBinding{})
 	builder.Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {

--- a/operators/networking/internal/cmd/ip-manager/manager/services.go
+++ b/operators/networking/internal/cmd/ip-manager/manager/services.go
@@ -188,18 +188,14 @@ func (m *Manager) DeregisterService(ctx context.Context, namespace, name string)
 		return nil
 	}
 
-	// delete(m.svcBindingsMap, fmt.Sprintf("%s/%s", svcBinding.Spec.ServiceRef.Namespace, svcBinding.Spec.ServiceRef.Name))
-
 	sb.Spec.ServiceIP = nil
 	sb.Spec.ServiceRef = nil
 	sb.Spec.Ports = nil
+	sb.Spec.Hostname = ""
 
-	lb := sb.Labels
-	if lb == nil {
-		lb = make(map[string]string, 1)
-	}
-	lb[svcReservationLabel] = "false"
-	sb.SetLabels(lb)
+	sb.SetLabels(map[string]string{
+		svcReservationLabel: "false",
+	})
 
 	delete(sb.Annotations, "kloudlite.io/global.hostname")
 	sb.SetAnnotations(sb.GetEnsuredAnnotations())


### PR DESCRIPTION
- setting `.spec.suspend` to true will suspend a kloudlite environment

Resolves #209
Resolves kloudlite/kloudlite#281

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add functionality to suspend environments by setting a new `suspend` field in the environment specification. Enhance pod affinity terms with new label key matching options and introduce a sleep duration for container termination. Update PersistentVolumeClaims with a new field for volume attributes, gated by a feature flag.

New Features:
- Introduce the ability to suspend and unsuspend environments by setting the `.spec.suspend` field in the environment specification.

Enhancements:
- Add support for `matchLabelKeys` and `mismatchLabelKeys` in pod affinity terms, allowing more granular control over pod selection based on labels.
- Introduce a `sleep` property for containers, specifying the duration a container should sleep before termination.
- Add `volumeAttributesClassName` to PersistentVolumeClaims for setting volume attributes, requiring the VolumeAttributesClass feature gate.

<!-- Generated by sourcery-ai[bot]: end summary -->