### PR TITLE
fix: now syncs all service bindings, irrespective of it being reserved

### DIFF
--- a/operators/resource-watcher/internal/controllers/watch-and-update/controller.go
+++ b/operators/resource-watcher/internal/controllers/watch-and-update/controller.go
@@ -261,10 +261,6 @@ func (r *Reconciler) dispatchEvent(ctx context.Context, logger logging.Logger, o
 
 	case ServiceBindingGVK.String():
 		{
-			if obj.GetLabels()[constants.KloudliteServiceBindingReservation] == "false" {
-				return nil
-			}
-
 			return r.MsgSender.DispatchConsoleResourceUpdates(MessageSenderContext{mctx, logger}, t.ResourceUpdate{
 				Object: obj,
 			})


### PR DESCRIPTION
Resolves kloudlite/kloudlite#283

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix synchronization of service bindings by removing the condition that restricted updates to only reserved bindings.

Bug Fixes:
- Ensure all service bindings are synchronized, regardless of their reservation status.

<!-- Generated by sourcery-ai[bot]: end summary -->