### PR TITLE
fixes recurring lifecycle resource updates

### DIFF
--- a/apis/crds/v1/app_types.go
+++ b/apis/crds/v1/app_types.go
@@ -227,8 +227,8 @@ type AppSpec struct {
 	Freeze    bool       `json:"freeze,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=kloudlite-svc-account
 	ServiceAccount string `json:"serviceAccount,omitempty"`
+
 	// +kubebuilder:default=1
 	Replicas   int            `json:"replicas,omitempty"`
 	Services   []AppSvc       `json:"services,omitempty"`

--- a/config/crd/bases/crds.kloudlite.io_apps.yaml
+++ b/config/crd/bases/crds.kloudlite.io_apps.yaml
@@ -392,7 +392,6 @@ spec:
                 - domains
                 type: object
               serviceAccount:
-                default: kloudlite-svc-account
                 type: string
               services:
                 items:

--- a/config/crd/bases/crds.kloudlite.io_blueprints.yaml
+++ b/config/crd/bases/crds.kloudlite.io_blueprints.yaml
@@ -394,7 +394,6 @@ spec:
                           - domains
                           type: object
                         serviceAccount:
-                          default: kloudlite-svc-account
                           type: string
                         services:
                           items:

--- a/operators/msvc-mongo/internal/controllers/standalone-database/controller.go
+++ b/operators/msvc-mongo/internal/controllers/standalone-database/controller.go
@@ -252,7 +252,8 @@ func (r *Reconciler) createDBUserLifecycle(req *rApi.Request[*mongov1.Standalone
 			return err
 		}
 
-		lf.Spec = lfres.Spec
+		lf.Spec.OnApply = lfres.Spec.OnApply
+		lf.Spec.OnDelete = lfres.Spec.OnDelete
 		return nil
 	}); err != nil {
 		return check.Failed(err)

--- a/operators/msvc-mysql/internal/controllers/standalone-database/controller.go
+++ b/operators/msvc-mysql/internal/controllers/standalone-database/controller.go
@@ -268,7 +268,9 @@ func (r *Reconciler) createDBUserLifecycle(req *rApi.Request[*mysqlv1.Standalone
 			return err
 		}
 
-		lf.Spec = lfres.Spec
+		lf.Spec.OnApply = lfres.Spec.OnApply
+		lf.Spec.OnDelete = lfres.Spec.OnDelete
+
 		return nil
 	}); err != nil {
 		return check.Failed(err)

--- a/operators/msvc-postgres/internal/controllers/standalone-database/controller.go
+++ b/operators/msvc-postgres/internal/controllers/standalone-database/controller.go
@@ -263,7 +263,9 @@ func (r *Reconciler) createDBUserLifecycle(req *rApi.Request[*postgresv1.Standal
 			return err
 		}
 
-		lf.Spec = lfres.Spec
+		lf.Spec.OnApply = lfres.Spec.OnApply
+		lf.Spec.OnDelete = lfres.Spec.OnDelete
+
 		return nil
 	}); err != nil {
 		return check.Failed(err)

--- a/operators/networking/internal/gateway/controller.go
+++ b/operators/networking/internal/gateway/controller.go
@@ -175,7 +175,8 @@ func (r *Reconciler) patchDefaults(req *rApi.Request[*networkingv1.Gateway]) ste
 
 	if obj.Spec.TargetNamespace == "" {
 		hasUpdate = true
-		obj.Spec.TargetNamespace = fmt.Sprintf("kl-gateway-%s", obj.Name)
+		// obj.Spec.TargetNamespace = fmt.Sprintf("kl-gateway-%s", obj.Name)
+		obj.Spec.TargetNamespace = fmt.Sprintf("kl-gateway", obj.Name)
 	}
 
 	if obj.Spec.WireguardKeysRef.Name == "" {


### PR DESCRIPTION
Resolves kloudlite/kloudlite#291
Resolves kloudlite/kloudlite#292

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix recurring lifecycle resource updates by adding a new step to patch defaults in the lifecycle controller. Enhance database user lifecycle creation by separately assigning OnApply and OnDelete specifications. Remove default serviceAccount values from CRD definitions.

Bug Fixes:
- Fix recurring lifecycle resource updates by introducing a new step to patch defaults in the lifecycle controller.

Enhancements:
- Add logic to patch default values in the lifecycle controller, ensuring that the RetryOnFailureDelay is set to 30 seconds if not specified.
- Update the database user lifecycle creation logic to separately assign OnApply and OnDelete specifications for MySQL, Postgres, and MongoDB controllers.

Chores:
- Remove the default value for the serviceAccount field in the CRD definitions for apps and blueprints.

<!-- Generated by sourcery-ai[bot]: end summary -->