### PR TITLE
feat: supports intercepting app on an ip addr

### DIFF
--- a/apis/crds/v1/app_types.go
+++ b/apis/crds/v1/app_types.go
@@ -254,6 +254,7 @@ type Intercept struct {
 
 	// +kubebuilder:validation:MinLength=1
 	ToDevice string `json:"toDevice"`
+	ToIPAddr string `json:"toIPAddr,omitempty"`
 
 	DeviceHostSuffix *string `json:"deviceHostSuffix,omitempty" graphql:"ignore"`
 

--- a/config/crd/bases/crds.kloudlite.io_apps.yaml
+++ b/config/crd/bases/crds.kloudlite.io_apps.yaml
@@ -297,9 +297,12 @@ spec:
                   toDevice:
                     minLength: 1
                     type: string
+                  toIPAddr:
+                    type: string
                 required:
                 - enabled
                 - toDevice
+                - toIPAddr
                 type: object
               nodeSelector:
                 additionalProperties:

--- a/config/crd/bases/crds.kloudlite.io_blueprints.yaml
+++ b/config/crd/bases/crds.kloudlite.io_blueprints.yaml
@@ -299,9 +299,12 @@ spec:
                             toDevice:
                               minLength: 1
                               type: string
+                            toIPAddr:
+                              type: string
                           required:
                           - enabled
                           - toDevice
+                          - toIPAddr
                           type: object
                         nodeSelector:
                           additionalProperties:

--- a/config/crd/bases/crds.kloudlite.io_externalapps.yaml
+++ b/config/crd/bases/crds.kloudlite.io_externalapps.yaml
@@ -69,9 +69,12 @@ spec:
                   toDevice:
                     minLength: 1
                     type: string
+                  toIPAddr:
+                    type: string
                 required:
                 - enabled
                 - toDevice
+                - toIPAddr
                 type: object
               record:
                 type: string

--- a/operators/app-n-lambda/internal/controllers/app/controller.go
+++ b/operators/app-n-lambda/internal/controllers/app/controller.go
@@ -278,13 +278,19 @@ func (r *Reconciler) checkAppIntercept(req *rApi.Request[*crdsv1.App]) stepResul
 				deviceHostSuffix = *obj.Spec.Intercept.DeviceHostSuffix
 			}
 
+			deviceHost := fmt.Sprintf("%s.%s", obj.Spec.Intercept.ToDevice, deviceHostSuffix)
+			if obj.Spec.Intercept.ToIPAddr != "" {
+				deviceHost = obj.Spec.Intercept.ToIPAddr
+			}
+
 			b, err := templates.ParseBytes(r.appInterceptTemplate, map[string]any{
 				"name":             podname,
 				"namespace":        podns,
 				"labels":           fn.MapMerge(fn.MapFilterWithPrefix(obj.Labels, "kloudlite.io/"), map[string]string{appGenerationLabel: fmt.Sprintf("%d", obj.Generation)}),
 				"owner-references": []metav1.OwnerReference{fn.AsOwner(obj, true)},
-				"device-host":      fmt.Sprintf("%s.%s", obj.Spec.Intercept.ToDevice, deviceHostSuffix),
-				"port-mappings":    portMappings,
+				// "device-host":      fmt.Sprintf("%s.%s", obj.Spec.Intercept.ToDevice, deviceHostSuffix),
+				"device-host":   deviceHost,
+				"port-mappings": portMappings,
 			})
 			if err != nil {
 				return check.Failed(err).NoRequeue()


### PR DESCRIPTION
- now, user can intercept app on a device, and also on an IPAddr

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce the ability to intercept applications on an IP address by adding a new 'toIPAddr' field to the intercept configuration. Update the CRD definitions to support this new field, allowing users to specify either a device or an IP address for interception.

New Features:
- Add support for intercepting applications on an IP address in addition to a device.

Enhancements:
- Update CRD definitions to include the new 'toIPAddr' field for intercept configurations.

<!-- Generated by sourcery-ai[bot]: end summary -->