### PR TITLE
Refactor pod-pinger to use pro-bing for ping operations

### DIFF
--- a/operators/networking/internal/gateway/templates/gateway-deployment.yml.tpl
+++ b/operators/networking/internal/gateway/templates/gateway-deployment.yml.tpl
@@ -43,6 +43,10 @@ spec:
         kloudlite.io/gateway-extra-peers-hash: {{.GatewayWgExtraPeersHash}}
     spec:
       serviceAccountName: {{.ServiceAccountName}}
+      securityContext:
+        sysctls:
+          - name: net.ipv4.ping_group_range
+            value: "0 2147483647"
       initContainers:
         - name: wg-hostnames
           image: ghcr.io/kloudlite/hub/wireguard:latest


### PR DESCRIPTION
Resolves kloudlite/kloudlite#297

## Summary by Sourcery

Refactor the pod-pinger to utilize the pro-bing library for improved ping operations and update the gateway deployment template to include a security context for sysctl configuration.

Enhancements:
- Refactor the pod-pinger to use the pro-bing library for ping operations, replacing the previous exec.CommandContext approach.

Deployment:
- Add a security context to the gateway deployment template to set the net.ipv4.ping_group_range sysctl parameter.