### PR TITLE
feat: add service account name handling, and improves in-cluster DNS resolution of kloudlite Apps

### DIFF
--- a/operators/app-n-lambda/internal/templates/app-deployment-svc-hpa.yml.tpl
+++ b/operators/app-n-lambda/internal/templates/app-deployment-svc-hpa.yml.tpl
@@ -8,6 +8,8 @@
 
 {{- /* {{- $clusterDnsSuffix := get . "cluster-dns-suffix" | default "cluster.local"}} */}}
 
+{{- $serviceAccountName := get . "service-account-name" | default "" }}
+
 {{- with $obj }}
 
 {{- $isIntercepted := (and .Spec.Intercept .Spec.Intercept.Enabled) }}
@@ -40,7 +42,7 @@ spec:
         {{ $podLabels | toYAML | nindent 8 }}
       annotations: {{$podAnnotations | toYAML | nindent 8 }}
     spec:
-      serviceAccountName: {{.Spec.ServiceAccount}}
+      serviceAccountName: {{$serviceAccountName}}
       nodeSelector: {{if .Spec.NodeSelector}}{{ .Spec.NodeSelector | toYAML | nindent 8 }}{{end}}
         {{- if .Spec.Region}}
         kloudlite.io/region: {{.Spec.Region | squote}}
@@ -59,20 +61,6 @@ spec:
       {{- end }}
 
       dnsPolicy: ClusterFirst
-
-      {{- /* affinity: */ -}}
-      {{- /*   nodeAffinity: */ -}}
-      {{- /*     preferredDuringSchedulingIgnoredDuringExecution: */ -}}
-      {{- /*       {{- $nWeight := 30 -}} */ -}}
-      {{- /*       {{- range $weight := Iterate $nWeight }} */ -}}
-      {{- /*       - weight: {{ sub $nWeight $weight }} */ -}}
-      {{- /*         preference: */ -}}
-      {{- /*           matchExpressions: */ -}}
-      {{- /*             - key: kloudlite.io/node-index */ -}}
-      {{- /*               operator: In */ -}}
-      {{- /*               values: */ -}}
-      {{- /*                 - {{$weight | squote}} */ -}}
-      {{- /*       {{- end }} */ -}}
 
       {{- if .Spec.Containers }}
       {{- $myDict := dict "containers" .Spec.Containers "volumeMounts" $vMounts }}

--- a/operators/networking/internal/cmd/webhook/main.go
+++ b/operators/networking/internal/cmd/webhook/main.go
@@ -198,6 +198,8 @@ while true; do
     wg-quick up kloudlite-wg
     %s
     echo "[SUCCESS] wireguard is up"
+    echo "search $POD_NAMESPACE.svc.cluster.local svc.cluster.local cluster.local" >> /etc/resolv.conf
+    echo "options ndots:5" >> /etc/resolv.conf
     exit 0
   fi
   echo "[RETRY] wireguard configuration could not be fetched from gateway ip-manager, retrying in 1 seconds"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -94,6 +94,7 @@ const (
 	EdgeNameKey                  string = "kloudlite.io/edge.name"
 	EdgeRouterNameKey            string = "kloudlite.io/edge-router.name"
 	EnvironmentNameKey           string = "kloudlite.io/environment.name"
+	EnvNameKey                   string = "kloudlite.io/env.name"
 	TargetNamespaceKey           string = "kloudlite.io/target-namespace"
 	ImagePullSecretNameKey       string = "kloudlite.io/image-pull-secret.name"
 	CsiDriverNameKey             string = "kloudlite.io/csi-driver.name"


### PR DESCRIPTION
Resolves kloudlite/kloudlite#303
Resolves kloudlite/kloudlite#303

## Summary by Sourcery

Add service account name handling in the application deployment process and update the logic for Horizontal Pod Autoscaler (HPA) configuration to better manage intercept and HPA enablement conditions.

New Features:
- Introduce handling for service account names in the application deployment process.

Enhancements:
- Update the logic for Horizontal Pod Autoscaler (HPA) configuration to improve handling of intercept and HPA enablement conditions.