### PR TITLE
fix: fixes dns query issue, changes ndots to 1

### DIFF
--- a/operators/networking/internal/cmd/webhook/main.go
+++ b/operators/networking/internal/cmd/webhook/main.go
@@ -198,8 +198,9 @@ while true; do
     wg-quick up kloudlite-wg
     %s
     echo "[SUCCESS] wireguard is up"
+
     echo "search $POD_NAMESPACE.svc.cluster.local svc.cluster.local cluster.local" >> /etc/resolv.conf
-    echo "options ndots:5" >> /etc/resolv.conf
+    echo "options ndots:1" >> /etc/resolv.conf
     exit 0
   fi
   echo "[RETRY] wireguard configuration could not be fetched from gateway ip-manager, retrying in 1 seconds"


### PR DESCRIPTION
initial reference was from k8s default pod /etc/resolv.conf, but it assumes `ndots:5`, which means a domain to have at least 5 dots to be qualified as a FQDN, which is kind of wrong in our use case

Resolves kloudlite/kloudlite#304

## Summary by Sourcery

Bug Fixes:
- Fix DNS query issue by changing the ndots option from 5 to 1 in the resolv.conf configuration.