### PR TITLE
chore: nodepool controller imported packages migrated to `toolkit` pkg

### DIFF
--- a/apis/clusters/v1/node_types.go
+++ b/apis/clusters/v1/node_types.go
@@ -4,7 +4,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kloudlite/operator/pkg/constants"
-	rApi "github.com/kloudlite/operator/pkg/operator"
+	"github.com/kloudlite/operator/toolkit/reconciler"
 )
 
 type NodeType string
@@ -26,7 +26,7 @@ type Node struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   NodeSpec    `json:"spec"`
-	Status rApi.Status `json:"status,omitempty" graphql:"noinput"`
+	Status reconciler.Status `json:"status,omitempty" graphql:"noinput"`
 }
 
 func (n *Node) EnsureGVK() {
@@ -35,7 +35,7 @@ func (n *Node) EnsureGVK() {
 	}
 }
 
-func (n *Node) GetStatus() *rApi.Status {
+func (n *Node) GetStatus() *reconciler.Status {
 	return &n.Status
 }
 

--- a/cmd/nodepool-operator/main.go
+++ b/cmd/nodepool-operator/main.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 
 	crdsv1 "github.com/kloudlite/operator/apis/crds/v1"
-	"github.com/kloudlite/operator/operator"
 	lifecycle "github.com/kloudlite/operator/operators/lifecycle/controller"
 	nodepool "github.com/kloudlite/operator/operators/nodepool/controller"
+	"github.com/kloudlite/operator/toolkit/operator"
 )
 
 func main() {

--- a/operators/nodepool/controller/register.go
+++ b/operators/nodepool/controller/register.go
@@ -2,23 +2,23 @@ package controller
 
 import (
 	clustersv1 "github.com/kloudlite/operator/apis/clusters/v1"
-	"github.com/kloudlite/operator/operator"
 	"github.com/kloudlite/operator/operators/nodepool/internal/env"
 	node_controller "github.com/kloudlite/operator/operators/nodepool/internal/node-controller"
 	nodepool_controller "github.com/kloudlite/operator/operators/nodepool/internal/nodepool-controller"
+	"github.com/kloudlite/operator/toolkit/operator"
 )
 
 func RegisterInto(mgr operator.Operator) {
 	ev := env.GetEnvOrDie()
 
 	if !ev.EnableNodepools {
-		mgr.Operator().Logger.Infof("nodepools controller is disabled")
+		mgr.Operator().Logger().Info("nodepools controller is disabled")
 		return
 	}
 
 	mgr.AddToSchemes(clustersv1.AddToScheme)
 	mgr.RegisterControllers(
-		&nodepool_controller.Reconciler{Env: ev, Name: "nodepool"},
-		&node_controller.Reconciler{Env: ev, Name: "nodepool:node"},
+		&nodepool_controller.Reconciler{Env: ev, Name: "nodepool", YAMLClient: mgr.Operator().KubeYAMLClient()},
+		&node_controller.Reconciler{Env: ev, Name: "nodepool:node", YAMLClient: mgr.Operator().KubeYAMLClient()},
 	)
 }

--- a/operators/nodepool/internal/node-controller/controller.go
+++ b/operators/nodepool/internal/node-controller/controller.go
@@ -9,10 +9,9 @@ import (
 
 	clustersv1 "github.com/kloudlite/operator/apis/clusters/v1"
 	fn "github.com/kloudlite/operator/pkg/functions"
-	"github.com/kloudlite/operator/pkg/kubectl"
-	"github.com/kloudlite/operator/pkg/logging"
-	rApi "github.com/kloudlite/operator/pkg/operator"
-	stepResult "github.com/kloudlite/operator/pkg/operator/step-result"
+	"github.com/kloudlite/operator/toolkit/kubectl"
+	rApi "github.com/kloudlite/operator/toolkit/reconciler"
+	stepResult "github.com/kloudlite/operator/toolkit/reconciler/step-result"
 	corev1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,9 +28,8 @@ type Reconciler struct {
 	client.Client
 	Scheme     *runtime.Scheme
 	Env        *env.Env
-	logger     logging.Logger
 	Name       string
-	yamlClient kubectl.YAMLClient
+	YAMLClient kubectl.YAMLClient
 }
 
 func (r *Reconciler) GetName() string {
@@ -52,7 +50,7 @@ const (
 // +kubebuilder:rbac:groups=clusters.kloudlite.io,resources=clusters/finalizers,verbs=update
 
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	req, err := rApi.NewRequest(rApi.NewReconcilerCtx(ctx, r.logger), r.Client, request.NamespacedName, &clustersv1.Node{})
+	req, err := rApi.NewRequest(ctx, r.Client, request.NamespacedName, &clustersv1.Node{})
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -187,7 +185,7 @@ func (r *Reconciler) finalize(req *rApi.Request[*clustersv1.Node]) stepResult.Re
 
 	t, err := time.Parse(time.RFC3339, node.Annotations[deleteAfterTimestamp])
 	if err != nil {
-		req.Logger.Infof("Failed to parse deleteAfterTimestamp: %v", err)
+		req.Logger.Info("Failed to parse deleteAfterTimestamp, got", "err", err)
 		t = time.Now().Add(-1 * time.Minute)
 	}
 
@@ -214,11 +212,13 @@ func (r *Reconciler) finalize(req *rApi.Request[*clustersv1.Node]) stepResult.Re
 	return check.StillRunning(fmt.Errorf("node will be deleted at %s", t.Format(time.RFC3339))).NoRequeue().RequeueAfter(time.Since(t))
 }
 
-func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, logger logging.Logger) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Client = mgr.GetClient()
 	r.Scheme = mgr.GetScheme()
-	r.logger = logger.WithName(r.Name)
-	r.yamlClient = kubectl.NewYAMLClientOrDie(mgr.GetConfig(), kubectl.YAMLClientOpts{Logger: r.logger})
+
+	if r.YAMLClient == nil {
+		return fmt.Errorf("YAMLClient must be provided")
+	}
 
 	builder := ctrl.NewControllerManagedBy(mgr).For(&clustersv1.Node{})
 

--- a/operators/nodepool/internal/nodepool-controller/cloudprovider-aws.go
+++ b/operators/nodepool/internal/nodepool-controller/cloudprovider-aws.go
@@ -95,7 +95,9 @@ func (r *Reconciler) AwsJobValuesJson(obj *clustersv1.NodePool, nodesMap map[str
 			"kloudlite-account": r.Env.AccountName,
 			"kloudlite-cluster": r.Env.ClusterName,
 		},
-		"kloudlite_release": r.Env.KloudliteRelease,
+		"kloudlite_release":             r.Env.KloudliteRelease,
+		"k3s_download_url":              "https://github.com/kloudlite/infrastructure-as-code/releases/download/binaries/k3s",
+		"kloudlite_runner_download_url": "https://github.com/kloudlite/infrastructure-as-code/releases/download/binaries/runner-amd64",
 	}
 
 	b, err := json.Marshal(variables)

--- a/operators/nodepool/main.go
+++ b/operators/nodepool/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/kloudlite/operator/operator"
 	"github.com/kloudlite/operator/operators/nodepool/controller"
+	"github.com/kloudlite/operator/toolkit/operator"
 )
 
 func main() {

--- a/operators/project/internal/controllers/environment/controller.go
+++ b/operators/project/internal/controllers/environment/controller.go
@@ -304,8 +304,7 @@ func (r *Reconciler) ensureNamespace(req *reconcinler.Request[*crdsv1.Environmen
 
 		ns.Annotations[constants.DescriptionKey] = fmt.Sprintf("this namespace is now being managed by kloudlite environment (%s)", obj.Name)
 
-		ns.SetOwnerReferences([]metav1.OwnerReference{fn.AsOwner(obj, true)})
-
+		// ns.SetOwnerReferences([]metav1.OwnerReference{fn.AsOwner(obj, true)})
 		return nil
 	}); err != nil {
 		return check.StillRunning(err)

--- a/toolkit/plugin/types.go
+++ b/toolkit/plugin/types.go
@@ -16,7 +16,7 @@ import (
 
 // +kubebuilder:object:generate=true
 type Export struct {
-	ViaSecret string `json:"viaSecret"`
+	ViaSecret string `json:"viaSecret,omitempty"`
 	Template  string `json:"template,omitempty"`
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Import packages from the `toolkit` package instead of the `operator` package.