### PR TITLE
feat: nodepool updates for AWS provider, now custom AMI-ID can be provided in spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,11 +89,13 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	@$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	# @$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	@$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./apis/..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	# $(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./apis/..."
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/apis/clusters/v1/nodepool_types.go
+++ b/apis/clusters/v1/nodepool_types.go
@@ -28,11 +28,13 @@ const (
 )
 
 type AwsEC2PoolConfig struct {
+	AMI          string               `json:"ami"`
 	InstanceType string               `json:"instanceType"`
 	Nodes        map[string]NodeProps `json:"nodes,omitempty"`
 }
 
 type AwsSpotPoolConfig struct {
+	AMI                      string               `json:"ami"`
 	SpotFleetTaggingRoleName string               `json:"spotFleetTaggingRoleName" graphql:"noinput"`
 	CpuNode                  *AwsSpotCpuNode      `json:"cpuNode,omitempty"`
 	GpuNode                  *AwsSpotGpuNode      `json:"gpuNode,omitempty"`

--- a/config/crd/bases/clusters.kloudlite.io_clusters.yaml
+++ b/config/crd/bases/clusters.kloudlite.io_clusters.yaml
@@ -135,6 +135,8 @@ spec:
                   nodePools:
                     additionalProperties:
                       properties:
+                        ami:
+                          type: string
                         instanceType:
                           type: string
                         nodes:
@@ -146,6 +148,7 @@ spec:
                             type: object
                           type: object
                       required:
+                      - ami
                       - instanceType
                       type: object
                     type: object
@@ -155,6 +158,8 @@ spec:
                   spotNodePools:
                     additionalProperties:
                       properties:
+                        ami:
+                          type: string
                         cpuNode:
                           properties:
                             memoryPerVcpu:
@@ -204,6 +209,7 @@ spec:
                         spotFleetTaggingRoleName:
                           type: string
                       required:
+                      - ami
                       - spotFleetTaggingRoleName
                       type: object
                     type: object

--- a/config/crd/bases/clusters.kloudlite.io_nodepools.yaml
+++ b/config/crd/bases/clusters.kloudlite.io_nodepools.yaml
@@ -62,6 +62,8 @@ spec:
                     type: string
                   ec2Pool:
                     properties:
+                      ami:
+                        type: string
                       instanceType:
                         type: string
                       nodes:
@@ -73,6 +75,7 @@ spec:
                           type: object
                         type: object
                     required:
+                    - ami
                     - instanceType
                     type: object
                   iamInstanceProfileRole:
@@ -92,6 +95,8 @@ spec:
                     type: string
                   spotPool:
                     properties:
+                      ami:
+                        type: string
                       cpuNode:
                         properties:
                           memoryPerVcpu:
@@ -141,6 +146,7 @@ spec:
                       spotFleetTaggingRoleName:
                         type: string
                     required:
+                    - ami
                     - spotFleetTaggingRoleName
                     type: object
                   vpcId:

--- a/config/crd/bases/clusters.kloudlite.io_nodes.yaml
+++ b/config/crd/bases/clusters.kloudlite.io_nodes.yaml
@@ -106,9 +106,6 @@ spec:
               lastReconcileTime:
                 format: date-time
                 type: string
-              message:
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
               resources:
                 items:
                   properties:

--- a/config/crd/bases/crds.kloudlite.io_clustermanagedservices.yaml
+++ b/config/crd/bases/crds.kloudlite.io_clustermanagedservices.yaml
@@ -66,8 +66,6 @@ spec:
                             type: string
                           viaSecret:
                             type: string
-                        required:
-                        - viaSecret
                         type: object
                       kind:
                         type: string
@@ -89,8 +87,6 @@ spec:
                             type: string
                           viaSecret:
                             type: string
-                        required:
-                        - viaSecret
                         type: object
                       kind:
                         type: string

--- a/config/crd/bases/crds.kloudlite.io_managedresources.yaml
+++ b/config/crd/bases/crds.kloudlite.io_managedresources.yaml
@@ -84,8 +84,6 @@ spec:
                         type: string
                       viaSecret:
                         type: string
-                    required:
-                    - viaSecret
                     type: object
                   kind:
                     type: string

--- a/config/crd/bases/crds.kloudlite.io_managedservices.yaml
+++ b/config/crd/bases/crds.kloudlite.io_managedservices.yaml
@@ -65,8 +65,6 @@ spec:
                         type: string
                       viaSecret:
                         type: string
-                    required:
-                    - viaSecret
                     type: object
                   kind:
                     type: string
@@ -88,8 +86,6 @@ spec:
                         type: string
                       viaSecret:
                         type: string
-                    required:
-                    - viaSecret
                     type: object
                   kind:
                     type: string

--- a/config/crd/bases/crds.kloudlite.io_projectmanagedservices.yaml
+++ b/config/crd/bases/crds.kloudlite.io_projectmanagedservices.yaml
@@ -84,8 +84,6 @@ spec:
                             type: string
                           viaSecret:
                             type: string
-                        required:
-                        - viaSecret
                         type: object
                       kind:
                         type: string
@@ -107,8 +105,6 @@ spec:
                             type: string
                           viaSecret:
                             type: string
-                        required:
-                        - viaSecret
                         type: object
                       kind:
                         type: string

--- a/operators/nodepool/internal/nodepool-controller/cloudprovider-aws.go
+++ b/operators/nodepool/internal/nodepool-controller/cloudprovider-aws.go
@@ -12,11 +12,8 @@ func (r *Reconciler) AwsJobValuesJson(obj *clustersv1.NodePool, nodesMap map[str
 		return "", fmt.Errorf(".spec.aws is nil")
 	}
 
-	// ec2Nodepools := make(map[string]any, 1)
-	// spotNodepools := make(map[string]any, 1)
-
-	ec2Nodepool := map[string]any{}
-	spotNodepool := map[string]any{}
+	ec2Nodepool := make(map[string]any)
+	spotNodepool := make(map[string]any)
 
 	switch obj.Spec.AWS.PoolType {
 	case clustersv1.AWSPoolTypeEC2:
@@ -25,6 +22,7 @@ func (r *Reconciler) AwsJobValuesJson(obj *clustersv1.NodePool, nodesMap map[str
 				"root_volume_type": obj.Spec.AWS.RootVolumeType,
 				"root_volume_size": obj.Spec.AWS.RootVolumeSize,
 				"instance_type":    obj.Spec.AWS.EC2Pool.InstanceType,
+				"ami":              obj.Spec.AWS.EC2Pool.AMI,
 				"nodes":            nodesMap,
 			}
 			spotNodepool = nil
@@ -36,6 +34,7 @@ func (r *Reconciler) AwsJobValuesJson(obj *clustersv1.NodePool, nodesMap map[str
 			}
 
 			spotNodepool = map[string]any{
+				"ami":                          obj.Spec.AWS.SpotPool.AMI,
 				"root_volume_type":             obj.Spec.AWS.RootVolumeType,
 				"root_volume_size":             obj.Spec.AWS.RootVolumeSize,
 				"spot_fleet_tagging_role_name": obj.Spec.AWS.SpotPool.SpotFleetTaggingRoleName,


### PR DESCRIPTION
## Summary by Sourcery

Introduce the ability to specify a custom AMI-ID in the AWS node pool configuration, enhancing flexibility for EC2 and Spot instances. Update the Makefile to adjust paths for controller-gen commands, ensuring proper code generation.

New Features:
- Allow custom AMI-ID to be specified in the AWS node pool configuration.

Enhancements:
- Refactor AWS node pool configuration to support custom AMI-ID for both EC2 and Spot instances.

Build:
- Update Makefile to modify paths for controller-gen commands.